### PR TITLE
[FEAT] RLUSD 토큰 에스크로 결제 지원 및 서비스 레이어 리팩토링

### DIFF
--- a/ci-check.sh
+++ b/ci-check.sh
@@ -11,7 +11,7 @@ fail() { echo -e "${RED}✗ $1${NC}"; exit 1; }
 step() { echo -e "\n${YELLOW}▶ $1${NC}"; }
 
 step "Prettier"
-npx prettier --check "src/**/*.ts" "test/**/*.ts" || fail "Prettier 실패 — npm run format 으로 수정하세요"
+npm run format && npx prettier --check "src/**/*.ts" "test/**/*.ts" || fail "Prettier 실패 — npm run format 으로 수정하세요"
 pass "Prettier"
 
 step "ESLint"

--- a/ci-check.sh
+++ b/ci-check.sh
@@ -26,4 +26,8 @@ step "E2E 테스트 (mock)"
 npm run test:e2e || fail "E2E 테스트 실패"
 pass "E2E 테스트 (mock)"
 
-echo -e "\n${GREEN}✓ 모든 검사 통과 — push 해도 됩니다${NC}"
+step "E2E 테스트 (실제)"
+npm run test:e2e:testnet && npm run test:e2e:rlusd-testnet || fail "E2E 테스트 실패"
+pass "E2E 테스트 (실제)"
+
+echo -e "\n${GREEN}✓ 모든 검사 통과!"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:e2e:testnet": "jest --config ./test/jest-e2e-testnet.json",
+    "test:e2e:rlusd-testnet": "jest --config ./test/jest-e2e-rlusd-testnet.json",
     "prepare": "husky || true"
   },
   "lint-staged": {

--- a/src/common/exceptions/escrow.exceptions.ts
+++ b/src/common/exceptions/escrow.exceptions.ts
@@ -13,6 +13,14 @@ export class InsufficientXrpBalanceException extends BadRequestException {
   }
 }
 
+export class InsufficientRlusdBalanceException extends BadRequestException {
+  constructor(available: number, required: number) {
+    super(
+      `Insufficient RLUSD balance: available ${available.toFixed(6)}, required ${required.toFixed(6)}`,
+    );
+  }
+}
+
 export class EscrowPaymentNotFoundException extends NotFoundException {
   constructor() {
     super("EscrowPayment not found");

--- a/src/modules/escrow-payments/__tests__/create.spec.ts
+++ b/src/modules/escrow-payments/__tests__/create.spec.ts
@@ -1,8 +1,8 @@
-import { BUYER_ID, SELLER_ID, makeServiceTestingModule } from "./helpers";
+import { BUYER_ID, SELLER_ID, makeCrudServiceTestingModule } from "./helpers";
 import { UnauthorizedPaymentActionException } from "../../../common/exceptions";
 
-describe("EscrowPaymentsService › create", () => {
-  let ctx: Awaited<ReturnType<typeof makeServiceTestingModule>>;
+describe("EscrowPaymentsCrudService › create", () => {
+  let ctx: Awaited<ReturnType<typeof makeCrudServiceTestingModule>>;
 
   const dto = {
     buyerId: BUYER_ID.toString(),
@@ -25,7 +25,7 @@ describe("EscrowPaymentsService › create", () => {
   };
 
   beforeEach(async () => {
-    ctx = await makeServiceTestingModule();
+    ctx = await makeCrudServiceTestingModule();
   });
 
   it("totalAmountXrp를 escrow 항목 합산으로 계산", async () => {

--- a/src/modules/escrow-payments/__tests__/helpers.ts
+++ b/src/modules/escrow-payments/__tests__/helpers.ts
@@ -1,7 +1,9 @@
 import { Test } from "@nestjs/testing";
 import { getModelToken } from "@nestjs/mongoose";
 import { Types } from "mongoose";
+import { EscrowPaymentsCrudService } from "../escrow-payments-crud.service";
 import { EscrowPaymentsService } from "../escrow-payments.service";
+import { EscrowCreateProcessor } from "../escrow-create.processor";
 import { EscrowPayment } from "../schemas/escrow-payment.schema";
 import { User } from "../../users/schemas/user.schema";
 import { XrplService } from "../../xrpl/xrpl.service";
@@ -168,6 +170,56 @@ export function makeOutboxServiceMock() {
 }
 
 // ── NestJS 테스팅 모듈 ────────────────────────────────────────────────────────
+
+export async function makeCrudServiceTestingModule() {
+  const escrowPaymentModel = makeEscrowPaymentModelMock();
+
+  const module = await Test.createTestingModule({
+    providers: [
+      EscrowPaymentsCrudService,
+      {
+        provide: getModelToken(EscrowPayment.name),
+        useValue: escrowPaymentModel,
+      },
+    ],
+  }).compile();
+
+  return {
+    service: module.get<EscrowPaymentsCrudService>(EscrowPaymentsCrudService),
+    escrowPaymentModel,
+  };
+}
+
+export async function makeProcessorTestingModule() {
+  const escrowPaymentModel = makeEscrowPaymentModelMock();
+  const userModel = makeUserModelMock();
+  const xrplService = makeXrplServiceMock();
+  const escrowPaymentsService = {
+    getEscrowStatus: jest.fn(),
+    rollbackAllEscrows: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const module = await Test.createTestingModule({
+    providers: [
+      EscrowCreateProcessor,
+      {
+        provide: getModelToken(EscrowPayment.name),
+        useValue: escrowPaymentModel,
+      },
+      { provide: getModelToken(User.name), useValue: userModel },
+      { provide: XrplService, useValue: xrplService },
+      { provide: EscrowPaymentsService, useValue: escrowPaymentsService },
+    ],
+  }).compile();
+
+  return {
+    processor: module.get<EscrowCreateProcessor>(EscrowCreateProcessor),
+    escrowPaymentModel,
+    userModel,
+    xrplService,
+    escrowPaymentsService,
+  };
+}
 
 export async function makeServiceTestingModule() {
   const escrowPaymentModel = makeEscrowPaymentModelMock();

--- a/src/modules/escrow-payments/__tests__/query.spec.ts
+++ b/src/modules/escrow-payments/__tests__/query.spec.ts
@@ -5,6 +5,7 @@ import {
   PAYMENT_ID,
   makePayment,
   makeQueryChain,
+  makeCrudServiceTestingModule,
   makeServiceTestingModule,
 } from "./helpers";
 import {
@@ -13,11 +14,11 @@ import {
   UnauthorizedPaymentActionException,
 } from "../../../common/exceptions";
 
-describe("EscrowPaymentsService › findAll", () => {
-  let ctx: Awaited<ReturnType<typeof makeServiceTestingModule>>;
+describe("EscrowPaymentsCrudService › findAll", () => {
+  let ctx: Awaited<ReturnType<typeof makeCrudServiceTestingModule>>;
 
   beforeEach(async () => {
-    ctx = await makeServiceTestingModule();
+    ctx = await makeCrudServiceTestingModule();
   });
 
   it("buyerId OR sellerId 조건으로 조회", async () => {
@@ -100,11 +101,11 @@ describe("EscrowPaymentsService › findAll", () => {
   });
 });
 
-describe("EscrowPaymentsService › findById", () => {
-  let ctx: Awaited<ReturnType<typeof makeServiceTestingModule>>;
+describe("EscrowPaymentsCrudService › findById", () => {
+  let ctx: Awaited<ReturnType<typeof makeCrudServiceTestingModule>>;
 
   beforeEach(async () => {
-    ctx = await makeServiceTestingModule();
+    ctx = await makeCrudServiceTestingModule();
   });
 
   it("존재하는 ID → 결제 내역 반환", async () => {

--- a/src/modules/escrow-payments/__tests__/recovery-scheduler.spec.ts
+++ b/src/modules/escrow-payments/__tests__/recovery-scheduler.spec.ts
@@ -267,7 +267,11 @@ describe("EscrowSubmitRecoveryScheduler › recoverSubmittingEscrow", () => {
       CONDITION,
     );
     expect(escrowPaymentModel.findOneAndUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ "escrows._id": expect.any(Types.ObjectId) }),
+      expect.objectContaining({
+        escrows: {
+          $elemMatch: expect.objectContaining({ status: "SUBMITTING" }),
+        },
+      }),
       expect.objectContaining({
         $set: expect.objectContaining({
           "escrows.$.status": "ESCROWED",

--- a/src/modules/escrow-payments/__tests__/recovery-scheduler.spec.ts
+++ b/src/modules/escrow-payments/__tests__/recovery-scheduler.spec.ts
@@ -5,11 +5,15 @@ import { EscrowSubmitRecoveryScheduler } from "../escrow-submit-recovery.schedul
 import { EscrowPayment } from "../schemas/escrow-payment.schema";
 import { User } from "../../users/schemas/user.schema";
 import { EscrowPaymentsService } from "../escrow-payments.service";
+import { XrplService } from "../../xrpl/xrpl.service";
 import {
   BUYER_ID,
   SELLER_ID,
   ESCROW_ID,
   PAYMENT_ID,
+  CONDITION,
+  TX_HASH_CREATE,
+  XRPL_SEQUENCE,
   makePayment,
   makeEscrowItem,
   makeBuyerUser,
@@ -18,13 +22,11 @@ import {
   makeUserModelMock,
 } from "./helpers";
 
-describe("EscrowSubmitRecoveryScheduler", () => {
+describe("EscrowSubmitRecoveryScheduler › recoverStuckSubmittingEscrows (스케줄링 로직)", () => {
   let scheduler: EscrowSubmitRecoveryScheduler;
   let escrowPaymentModel: ReturnType<typeof makeEscrowPaymentModelMock>;
   let userModel: ReturnType<typeof makeUserModelMock>;
-  let escrowPaymentsService: jest.Mocked<
-    Pick<EscrowPaymentsService, "recoverSubmittingEscrow">
-  >;
+  let recoverSpy: jest.SpyInstance;
 
   const OLD_DATE = new Date(Date.now() - 10 * 60 * 1000); // 10분 전
 
@@ -46,9 +48,6 @@ describe("EscrowSubmitRecoveryScheduler", () => {
   beforeEach(async () => {
     escrowPaymentModel = makeEscrowPaymentModelMock();
     userModel = makeUserModelMock();
-    escrowPaymentsService = {
-      recoverSubmittingEscrow: jest.fn().mockResolvedValue("recovered"),
-    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -59,8 +58,17 @@ describe("EscrowSubmitRecoveryScheduler", () => {
         },
         { provide: getModelToken(User.name), useValue: userModel },
         {
+          provide: XrplService,
+          useValue: {
+            findEscrowByCondition: jest.fn().mockResolvedValue(null),
+          },
+        },
+        {
           provide: EscrowPaymentsService,
-          useValue: escrowPaymentsService,
+          useValue: {
+            getEscrowStatus: jest.fn(),
+            rollbackAllEscrows: jest.fn().mockResolvedValue(undefined),
+          },
         },
       ],
     }).compile();
@@ -68,6 +76,13 @@ describe("EscrowSubmitRecoveryScheduler", () => {
     scheduler = module.get<EscrowSubmitRecoveryScheduler>(
       EscrowSubmitRecoveryScheduler,
     );
+    recoverSpy = jest
+      .spyOn(scheduler, "recoverSubmittingEscrow")
+      .mockResolvedValue("recovered");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("SUBMITTING 없으면 → recoverSubmittingEscrow 미호출", async () => {
@@ -75,9 +90,7 @@ describe("EscrowSubmitRecoveryScheduler", () => {
 
     await scheduler.recoverStuckSubmittingEscrows();
 
-    expect(
-      escrowPaymentsService.recoverSubmittingEscrow,
-    ).not.toHaveBeenCalled();
+    expect(recoverSpy).not.toHaveBeenCalled();
   });
 
   it("5분 이상된 SUBMITTING 에스크로 → recoverSubmittingEscrow 호출", async () => {
@@ -87,7 +100,7 @@ describe("EscrowSubmitRecoveryScheduler", () => {
 
     await scheduler.recoverStuckSubmittingEscrows();
 
-    expect(escrowPaymentsService.recoverSubmittingEscrow).toHaveBeenCalledWith(
+    expect(recoverSpy).toHaveBeenCalledWith(
       PAYMENT_ID.toString(),
       ESCROW_ID.toString(),
       "rBuyerAddress123",
@@ -102,9 +115,7 @@ describe("EscrowSubmitRecoveryScheduler", () => {
 
     await scheduler.recoverStuckSubmittingEscrows();
 
-    expect(
-      escrowPaymentsService.recoverSubmittingEscrow,
-    ).not.toHaveBeenCalled();
+    expect(recoverSpy).not.toHaveBeenCalled();
   });
 
   it("buyer 지갑 없으면 → skip, 다른 payment는 계속 처리", async () => {
@@ -121,18 +132,14 @@ describe("EscrowSubmitRecoveryScheduler", () => {
 
     await scheduler.recoverStuckSubmittingEscrows();
 
-    expect(escrowPaymentsService.recoverSubmittingEscrow).toHaveBeenCalledTimes(
-      1,
-    );
+    expect(recoverSpy).toHaveBeenCalledTimes(1);
   });
 
   it("recovered → 에러 없이 정상 완료", async () => {
     const payment = makeStuckPayment();
     escrowPaymentModel.find.mockReturnValue(makeQueryChain([payment]));
     userModel.findById.mockReturnValue(makeQueryChain(makeBuyerUser()));
-    escrowPaymentsService.recoverSubmittingEscrow.mockResolvedValue(
-      "recovered",
-    );
+    recoverSpy.mockResolvedValue("recovered");
 
     await expect(
       scheduler.recoverStuckSubmittingEscrows(),
@@ -143,9 +150,7 @@ describe("EscrowSubmitRecoveryScheduler", () => {
     const payment = makeStuckPayment();
     escrowPaymentModel.find.mockReturnValue(makeQueryChain([payment]));
     userModel.findById.mockReturnValue(makeQueryChain(makeBuyerUser()));
-    escrowPaymentsService.recoverSubmittingEscrow.mockResolvedValue(
-      "cancelled",
-    );
+    recoverSpy.mockResolvedValue("cancelled");
 
     await expect(
       scheduler.recoverStuckSubmittingEscrows(),
@@ -167,7 +172,7 @@ describe("EscrowSubmitRecoveryScheduler", () => {
     escrowPaymentModel.find.mockReturnValue(makeQueryChain([payment]));
     userModel.findById.mockReturnValue(makeQueryChain(makeBuyerUser()));
 
-    escrowPaymentsService.recoverSubmittingEscrow
+    recoverSpy
       .mockRejectedValueOnce(new Error("XRPL connection error"))
       .mockResolvedValueOnce("recovered");
 
@@ -175,9 +180,7 @@ describe("EscrowSubmitRecoveryScheduler", () => {
       scheduler.recoverStuckSubmittingEscrows(),
     ).resolves.toBeUndefined();
 
-    expect(escrowPaymentsService.recoverSubmittingEscrow).toHaveBeenCalledTimes(
-      2,
-    );
+    expect(recoverSpy).toHaveBeenCalledTimes(2);
   });
 
   it("$elemMatch로 status=SUBMITTING AND submittingAt<cutoff 조건 조회", async () => {
@@ -193,5 +196,172 @@ describe("EscrowSubmitRecoveryScheduler", () => {
         },
       },
     });
+  });
+});
+
+// ── recoverSubmittingEscrow 로직 테스트 ─────────────────────────────────────
+
+describe("EscrowSubmitRecoveryScheduler › recoverSubmittingEscrow", () => {
+  let scheduler: EscrowSubmitRecoveryScheduler;
+  let escrowPaymentModel: ReturnType<typeof makeEscrowPaymentModelMock>;
+  let userModel: ReturnType<typeof makeUserModelMock>;
+  let xrplService: { findEscrowByCondition: jest.Mock };
+  let escrowPaymentsService: {
+    getEscrowStatus: jest.Mock;
+    rollbackAllEscrows: jest.Mock;
+  };
+
+  const BUYER_ADDRESS = "rBuyerAddress123";
+
+  beforeEach(async () => {
+    escrowPaymentModel = makeEscrowPaymentModelMock();
+    userModel = makeUserModelMock();
+    xrplService = { findEscrowByCondition: jest.fn().mockResolvedValue(null) };
+    escrowPaymentsService = {
+      getEscrowStatus: jest.fn(),
+      rollbackAllEscrows: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EscrowSubmitRecoveryScheduler,
+        {
+          provide: getModelToken(EscrowPayment.name),
+          useValue: escrowPaymentModel,
+        },
+        { provide: getModelToken(User.name), useValue: userModel },
+        { provide: XrplService, useValue: xrplService },
+        { provide: EscrowPaymentsService, useValue: escrowPaymentsService },
+      ],
+    }).compile();
+
+    scheduler = module.get<EscrowSubmitRecoveryScheduler>(
+      EscrowSubmitRecoveryScheduler,
+    );
+  });
+
+  it("XRPL에 에스크로 있음 → DB 업데이트 후 recovered 반환", async () => {
+    const submittingEscrow = makeEscrowItem({
+      status: "SUBMITTING",
+      condition: CONDITION,
+    });
+    escrowPaymentsService.getEscrowStatus.mockResolvedValue(submittingEscrow);
+    xrplService.findEscrowByCondition.mockResolvedValue({
+      txHash: TX_HASH_CREATE,
+      sequence: XRPL_SEQUENCE,
+    });
+    const escrowedResult = makePayment({
+      escrows: [makeEscrowItem({ status: "ESCROWED" })],
+    });
+    escrowPaymentModel.findOneAndUpdate.mockResolvedValue(escrowedResult);
+
+    const result = await scheduler.recoverSubmittingEscrow(
+      PAYMENT_ID.toString(),
+      ESCROW_ID.toString(),
+      BUYER_ADDRESS,
+    );
+
+    expect(result).toBe("recovered");
+    expect(xrplService.findEscrowByCondition).toHaveBeenCalledWith(
+      BUYER_ADDRESS,
+      CONDITION,
+    );
+    expect(escrowPaymentModel.findOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ "escrows._id": expect.any(Types.ObjectId) }),
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          "escrows.$.status": "ESCROWED",
+          "escrows.$.xrplSequence": XRPL_SEQUENCE,
+          "escrows.$.txHashCreate": TX_HASH_CREATE,
+        }),
+      }),
+      expect.objectContaining({ new: true }),
+    );
+  });
+
+  it("XRPL에 에스크로 없음 → 결제 취소 후 cancelled 반환", async () => {
+    const submittingEscrow = makeEscrowItem({
+      status: "SUBMITTING",
+      condition: CONDITION,
+    });
+    escrowPaymentsService.getEscrowStatus.mockResolvedValue(submittingEscrow);
+    xrplService.findEscrowByCondition.mockResolvedValue(null);
+    escrowPaymentModel.findOneAndUpdate.mockResolvedValue(makePayment());
+
+    const result = await scheduler.recoverSubmittingEscrow(
+      PAYMENT_ID.toString(),
+      ESCROW_ID.toString(),
+      BUYER_ADDRESS,
+    );
+
+    expect(result).toBe("cancelled");
+    expect(escrowPaymentModel.findOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ "escrows.status": "SUBMITTING" }),
+      { $set: { "escrows.$.status": "CANCELLED" } },
+    );
+    expect(escrowPaymentsService.rollbackAllEscrows).toHaveBeenCalledWith(
+      PAYMENT_ID.toString(),
+    );
+  });
+
+  it("condition 미저장 (pre-flight 전 크래시) → XRPL 조회 없이 즉시 취소", async () => {
+    const submittingEscrow = makeEscrowItem({
+      status: "SUBMITTING",
+      condition: undefined,
+    });
+    escrowPaymentsService.getEscrowStatus.mockResolvedValue(submittingEscrow);
+    escrowPaymentModel.findOneAndUpdate.mockResolvedValue(makePayment());
+
+    const result = await scheduler.recoverSubmittingEscrow(
+      PAYMENT_ID.toString(),
+      ESCROW_ID.toString(),
+      BUYER_ADDRESS,
+    );
+
+    expect(result).toBe("cancelled");
+    expect(xrplService.findEscrowByCondition).not.toHaveBeenCalled();
+  });
+
+  it("이미 SUBMITTING 아닌 상태 → 즉시 recovered 반환 (중복 복구 방지)", async () => {
+    const escrowedItem = makeEscrowItem({ status: "ESCROWED" });
+    escrowPaymentsService.getEscrowStatus.mockResolvedValue(escrowedItem);
+
+    const result = await scheduler.recoverSubmittingEscrow(
+      PAYMENT_ID.toString(),
+      ESCROW_ID.toString(),
+      BUYER_ADDRESS,
+    );
+
+    expect(result).toBe("recovered");
+    expect(xrplService.findEscrowByCondition).not.toHaveBeenCalled();
+    expect(escrowPaymentModel.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it("복구 후 모든 escrow ESCROWED → payment ACTIVE 전환", async () => {
+    const submittingEscrow = makeEscrowItem({
+      status: "SUBMITTING",
+      condition: CONDITION,
+    });
+    escrowPaymentsService.getEscrowStatus.mockResolvedValue(submittingEscrow);
+    xrplService.findEscrowByCondition.mockResolvedValue({
+      txHash: TX_HASH_CREATE,
+      sequence: XRPL_SEQUENCE,
+    });
+    const allEscrowedResult = makePayment({
+      status: "PROCESSING",
+      escrows: [makeEscrowItem({ status: "ESCROWED" })],
+    });
+    escrowPaymentModel.findOneAndUpdate.mockResolvedValue(allEscrowedResult);
+
+    await scheduler.recoverSubmittingEscrow(
+      PAYMENT_ID.toString(),
+      ESCROW_ID.toString(),
+      BUYER_ADDRESS,
+    );
+
+    expect(escrowPaymentModel.findByIdAndUpdate).toHaveBeenCalledWith(
+      PAYMENT_ID.toString(),
+      { $set: { status: "ACTIVE" } },
+    );
   });
 });

--- a/src/modules/escrow-payments/__tests__/xrpl.spec.ts
+++ b/src/modules/escrow-payments/__tests__/xrpl.spec.ts
@@ -146,7 +146,11 @@ describe("EscrowCreateProcessor › createXrplEscrow", () => {
 
     expect(ctx.escrowPaymentModel.findOneAndUpdate).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ "escrows.status": "PENDING_ESCROW" }),
+      expect.objectContaining({
+        escrows: {
+          $elemMatch: expect.objectContaining({ status: "PENDING_ESCROW" }),
+        },
+      }),
       expect.objectContaining({
         $set: expect.objectContaining({
           "escrows.$.status": "SUBMITTING",
@@ -285,7 +289,11 @@ describe("EscrowCreateProcessor › createXrplEscrow", () => {
     // findOneAndUpdate 호출: 1) pre-flight, 2) revert(SUBMITTING→PENDING_ESCROW)
     expect(ctx.escrowPaymentModel.findOneAndUpdate).toHaveBeenCalledTimes(2);
     expect(ctx.escrowPaymentModel.findOneAndUpdate).toHaveBeenLastCalledWith(
-      expect.objectContaining({ "escrows.status": "SUBMITTING" }),
+      expect.objectContaining({
+        escrows: {
+          $elemMatch: expect.objectContaining({ status: "SUBMITTING" }),
+        },
+      }),
       { $set: { "escrows.$.status": "PENDING_ESCROW" } },
     );
   });

--- a/src/modules/escrow-payments/__tests__/xrpl.spec.ts
+++ b/src/modules/escrow-payments/__tests__/xrpl.spec.ts
@@ -12,7 +12,7 @@ import {
   makeBuyerUser,
   makeSellerUser,
   makeQueryChain,
-  makeServiceTestingModule,
+  makeProcessorTestingModule,
 } from "./helpers";
 import {
   EscrowPaymentNotFoundException,
@@ -21,8 +21,8 @@ import {
   WalletNotAvailableException,
 } from "../../../common/exceptions";
 
-describe("EscrowPaymentsService › createXrplEscrow", () => {
-  let ctx: Awaited<ReturnType<typeof makeServiceTestingModule>>;
+describe("EscrowCreateProcessor › createXrplEscrow", () => {
+  let ctx: Awaited<ReturnType<typeof makeProcessorTestingModule>>;
 
   // post-flight findOneAndUpdate 결과로 사용할 ESCROWED 상태 payment 픽스처
   function makeEscrowedResult(escrowOverrides: object = {}) {
@@ -64,7 +64,7 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
   }
 
   beforeEach(async () => {
-    ctx = await makeServiceTestingModule();
+    ctx = await makeProcessorTestingModule();
   });
 
   // ── 유효성 검사 ──────────────────────────────────────────────────────────────
@@ -74,7 +74,10 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
 
     await expect(
-      ctx.service.createXrplEscrow(PAYMENT_ID.toString(), ESCROW_ID.toString()),
+      ctx.processor.createXrplEscrow(
+        PAYMENT_ID.toString(),
+        ESCROW_ID.toString(),
+      ),
     ).rejects.toThrow(PaymentNotActiveException);
   });
 
@@ -86,7 +89,10 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
 
     await expect(
-      ctx.service.createXrplEscrow(PAYMENT_ID.toString(), ESCROW_ID.toString()),
+      ctx.processor.createXrplEscrow(
+        PAYMENT_ID.toString(),
+        ESCROW_ID.toString(),
+      ),
     ).rejects.toThrow(InvalidEscrowItemStatusException);
   });
 
@@ -94,7 +100,10 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(null));
 
     await expect(
-      ctx.service.createXrplEscrow(PAYMENT_ID.toString(), ESCROW_ID.toString()),
+      ctx.processor.createXrplEscrow(
+        PAYMENT_ID.toString(),
+        ESCROW_ID.toString(),
+      ),
     ).rejects.toThrow(EscrowPaymentNotFoundException);
   });
 
@@ -103,7 +112,10 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     ctx.userModel.findById.mockReturnValue(makeQueryChain({ wallet: null }));
 
     await expect(
-      ctx.service.createXrplEscrow(PAYMENT_ID.toString(), ESCROW_ID.toString()),
+      ctx.processor.createXrplEscrow(
+        PAYMENT_ID.toString(),
+        ESCROW_ID.toString(),
+      ),
     ).rejects.toThrow(WalletNotAvailableException);
   });
 
@@ -114,7 +126,10 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
       .mockReturnValueOnce(makeQueryChain({ wallet: null }));
 
     await expect(
-      ctx.service.createXrplEscrow(PAYMENT_ID.toString(), ESCROW_ID.toString()),
+      ctx.processor.createXrplEscrow(
+        PAYMENT_ID.toString(),
+        ESCROW_ID.toString(),
+      ),
     ).rejects.toThrow(WalletNotAvailableException);
   });
 
@@ -124,7 +139,7 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     setupProcessingPayment();
     setupWallets();
 
-    await ctx.service.createXrplEscrow(
+    await ctx.processor.createXrplEscrow(
       PAYMENT_ID.toString(),
       ESCROW_ID.toString(),
     );
@@ -147,7 +162,7 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     setupProcessingPayment();
     setupWallets();
 
-    await ctx.service.createXrplEscrow(
+    await ctx.processor.createXrplEscrow(
       PAYMENT_ID.toString(),
       ESCROW_ID.toString(),
     );
@@ -158,6 +173,7 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
       "rSellerAddress456",
       300,
       CONDITION,
+      "XRP",
     );
   });
 
@@ -165,7 +181,7 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     setupProcessingPayment();
     setupWallets();
 
-    await ctx.service.createXrplEscrow(
+    await ctx.processor.createXrplEscrow(
       PAYMENT_ID.toString(),
       ESCROW_ID.toString(),
     );
@@ -178,6 +194,7 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
       expect.any(String),
       expect.any(Number),
       expect.any(String),
+      "XRP",
     );
   });
 
@@ -185,7 +202,7 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     setupProcessingPayment();
     setupWallets();
 
-    await ctx.service.createXrplEscrow(
+    await ctx.processor.createXrplEscrow(
       PAYMENT_ID.toString(),
       ESCROW_ID.toString(),
     );
@@ -209,7 +226,7 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     setupProcessingPayment();
     setupWallets();
 
-    const result = await ctx.service.createXrplEscrow(
+    const result = await ctx.processor.createXrplEscrow(
       PAYMENT_ID.toString(),
       ESCROW_ID.toString(),
     );
@@ -232,10 +249,7 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     });
     const partialResult = makePayment({
       status: "PROCESSING",
-      escrows: [
-        makeEscrowItem({ status: "ESCROWED" }),
-        extraEscrow, // 여전히 PENDING_ESCROW
-      ],
+      escrows: [makeEscrowItem({ status: "ESCROWED" }), extraEscrow],
     });
 
     ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
@@ -244,7 +258,7 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
       .mockResolvedValueOnce(partialResult);
     setupWallets();
 
-    await ctx.service.createXrplEscrow(
+    await ctx.processor.createXrplEscrow(
       PAYMENT_ID.toString(),
       ESCROW_ID.toString(),
     );
@@ -262,7 +276,10 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     );
 
     await expect(
-      ctx.service.createXrplEscrow(PAYMENT_ID.toString(), ESCROW_ID.toString()),
+      ctx.processor.createXrplEscrow(
+        PAYMENT_ID.toString(),
+        ESCROW_ID.toString(),
+      ),
     ).rejects.toThrow("XRPL network error");
 
     // findOneAndUpdate 호출: 1) pre-flight, 2) revert(SUBMITTING→PENDING_ESCROW)
@@ -279,7 +296,10 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     ctx.xrplService.createEscrow.mockRejectedValue(new Error("XRPL error"));
 
     await expect(
-      ctx.service.createXrplEscrow(PAYMENT_ID.toString(), ESCROW_ID.toString()),
+      ctx.processor.createXrplEscrow(
+        PAYMENT_ID.toString(),
+        ESCROW_ID.toString(),
+      ),
     ).rejects.toThrow();
 
     // pre-flight(1) + revert(1) = 2회, post-flight는 없음
@@ -302,7 +322,7 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
       .mockResolvedValueOnce(escrowedResult); // post-flight 2회 성공
     setupWallets();
 
-    const result = await ctx.service.createXrplEscrow(
+    const result = await ctx.processor.createXrplEscrow(
       PAYMENT_ID.toString(),
       ESCROW_ID.toString(),
     );
@@ -326,157 +346,13 @@ describe("EscrowPaymentsService › createXrplEscrow", () => {
     setupWallets();
 
     await expect(
-      ctx.service.createXrplEscrow(PAYMENT_ID.toString(), ESCROW_ID.toString()),
+      ctx.processor.createXrplEscrow(
+        PAYMENT_ID.toString(),
+        ESCROW_ID.toString(),
+      ),
     ).rejects.toThrow("DB write error");
 
     // pre-flight(1) + post-flight 3회 = 총 4회
     expect(ctx.escrowPaymentModel.findOneAndUpdate).toHaveBeenCalledTimes(4);
   }, 10_000);
-});
-
-// ── recoverSubmittingEscrow ───────────────────────────────────────────────────
-
-describe("EscrowPaymentsService › recoverSubmittingEscrow", () => {
-  let ctx: Awaited<ReturnType<typeof makeServiceTestingModule>>;
-
-  const BUYER_ADDRESS = "rBuyerAddress123";
-
-  beforeEach(async () => {
-    ctx = await makeServiceTestingModule();
-  });
-
-  it("XRPL에 에스크로 있음 → DB 업데이트 후 recovered 반환", async () => {
-    const submittingPayment = makePayment({
-      escrows: [makeEscrowItem({ status: "SUBMITTING", condition: CONDITION })],
-    });
-    ctx.escrowPaymentModel.findById.mockReturnValue(
-      makeQueryChain(submittingPayment),
-    );
-    ctx.xrplService.findEscrowByCondition.mockResolvedValue({
-      txHash: TX_HASH_CREATE,
-      sequence: XRPL_SEQUENCE,
-    });
-    const escrowedResult = makePayment({
-      escrows: [makeEscrowItem({ status: "ESCROWED" })],
-    });
-    ctx.escrowPaymentModel.findOneAndUpdate.mockResolvedValue(escrowedResult);
-
-    const result = await ctx.service.recoverSubmittingEscrow(
-      PAYMENT_ID.toString(),
-      ESCROW_ID.toString(),
-      BUYER_ADDRESS,
-    );
-
-    expect(result).toBe("recovered");
-    expect(ctx.xrplService.findEscrowByCondition).toHaveBeenCalledWith(
-      BUYER_ADDRESS,
-      CONDITION,
-    );
-    expect(ctx.escrowPaymentModel.findOneAndUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ "escrows._id": expect.any(Types.ObjectId) }),
-      expect.objectContaining({
-        $set: expect.objectContaining({
-          "escrows.$.status": "ESCROWED",
-          "escrows.$.xrplSequence": XRPL_SEQUENCE,
-          "escrows.$.txHashCreate": TX_HASH_CREATE,
-        }),
-      }),
-      expect.objectContaining({ new: true }),
-    );
-  });
-
-  it("XRPL에 에스크로 없음 → 결제 취소 후 cancelled 반환", async () => {
-    const submittingPayment = makePayment({
-      status: "PROCESSING",
-      escrows: [makeEscrowItem({ status: "SUBMITTING", condition: CONDITION })],
-    });
-    ctx.escrowPaymentModel.findById
-      .mockReturnValueOnce(makeQueryChain(submittingPayment)) // getEscrowStatus
-      .mockReturnValueOnce(makeQueryChain(submittingPayment)); // rollbackAllEscrows
-    ctx.xrplService.findEscrowByCondition.mockResolvedValue(null);
-    ctx.escrowPaymentModel.findOneAndUpdate.mockResolvedValue(
-      submittingPayment,
-    );
-
-    const result = await ctx.service.recoverSubmittingEscrow(
-      PAYMENT_ID.toString(),
-      ESCROW_ID.toString(),
-      BUYER_ADDRESS,
-    );
-
-    expect(result).toBe("cancelled");
-    // SUBMITTING → CANCELLED 명시 전환
-    expect(ctx.escrowPaymentModel.findOneAndUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ "escrows.status": "SUBMITTING" }),
-      { $set: { "escrows.$.status": "CANCELLED" } },
-    );
-  });
-
-  it("condition 미저장 (pre-flight 전 크래시) → XRPL 조회 없이 즉시 취소", async () => {
-    const payment = makePayment({
-      status: "PROCESSING",
-      escrows: [makeEscrowItem({ status: "SUBMITTING", condition: undefined })],
-    });
-    ctx.escrowPaymentModel.findById
-      .mockReturnValueOnce(makeQueryChain(payment))
-      .mockReturnValueOnce(makeQueryChain(payment));
-    ctx.escrowPaymentModel.findOneAndUpdate.mockResolvedValue(payment);
-
-    const result = await ctx.service.recoverSubmittingEscrow(
-      PAYMENT_ID.toString(),
-      ESCROW_ID.toString(),
-      BUYER_ADDRESS,
-    );
-
-    expect(result).toBe("cancelled");
-    expect(ctx.xrplService.findEscrowByCondition).not.toHaveBeenCalled();
-  });
-
-  it("이미 SUBMITTING 아닌 상태 → 즉시 recovered 반환 (중복 복구 방지)", async () => {
-    const payment = makePayment({
-      escrows: [makeEscrowItem({ status: "ESCROWED" })],
-    });
-    ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
-
-    const result = await ctx.service.recoverSubmittingEscrow(
-      PAYMENT_ID.toString(),
-      ESCROW_ID.toString(),
-      BUYER_ADDRESS,
-    );
-
-    expect(result).toBe("recovered");
-    expect(ctx.xrplService.findEscrowByCondition).not.toHaveBeenCalled();
-    expect(ctx.escrowPaymentModel.findOneAndUpdate).not.toHaveBeenCalled();
-  });
-
-  it("복구 후 모든 escrow ESCROWED → payment ACTIVE 전환", async () => {
-    const submittingPayment = makePayment({
-      escrows: [makeEscrowItem({ status: "SUBMITTING", condition: CONDITION })],
-    });
-    ctx.escrowPaymentModel.findById.mockReturnValue(
-      makeQueryChain(submittingPayment),
-    );
-    ctx.xrplService.findEscrowByCondition.mockResolvedValue({
-      txHash: TX_HASH_CREATE,
-      sequence: XRPL_SEQUENCE,
-    });
-    const allEscrowedResult = makePayment({
-      status: "PROCESSING",
-      escrows: [makeEscrowItem({ status: "ESCROWED" })],
-    });
-    ctx.escrowPaymentModel.findOneAndUpdate.mockResolvedValue(
-      allEscrowedResult,
-    );
-
-    await ctx.service.recoverSubmittingEscrow(
-      PAYMENT_ID.toString(),
-      ESCROW_ID.toString(),
-      BUYER_ADDRESS,
-    );
-
-    expect(ctx.escrowPaymentModel.findByIdAndUpdate).toHaveBeenCalledWith(
-      PAYMENT_ID.toString(),
-      { $set: { status: "ACTIVE" } },
-    );
-  });
 });

--- a/src/modules/escrow-payments/dto/create-escrow-payment.dto.ts
+++ b/src/modules/escrow-payments/dto/create-escrow-payment.dto.ts
@@ -3,6 +3,7 @@ import { Type } from "class-transformer";
 import {
   IsArray,
   ArrayMinSize,
+  IsEnum,
   IsInt,
   IsMongoId,
   IsNumber,
@@ -61,6 +62,16 @@ export class CreateEscrowPaymentDto {
   @IsString()
   @IsOptional()
   memo?: string;
+
+  @ApiProperty({
+    description: "결제 통화 (XRP 또는 RLUSD)",
+    enum: ["XRP", "RLUSD"],
+    default: "XRP",
+    required: false,
+  })
+  @IsEnum(["XRP", "RLUSD"])
+  @IsOptional()
+  currency?: "XRP" | "RLUSD";
 
   @ApiProperty({
     description: "에스크로 항목 목록 (초기금/중도금/잔금 등)",

--- a/src/modules/escrow-payments/escrow-create.processor.ts
+++ b/src/modules/escrow-payments/escrow-create.processor.ts
@@ -177,8 +177,7 @@ export class EscrowCreateProcessor {
     const preFlighted = await this.escrowPaymentModel.findOneAndUpdate(
       {
         _id: paymentId,
-        "escrows._id": escrow._id,
-        "escrows.status": "PENDING_ESCROW",
+        escrows: { $elemMatch: { _id: escrow._id, status: "PENDING_ESCROW" } },
       },
       {
         $set: {
@@ -196,36 +195,36 @@ export class EscrowCreateProcessor {
       );
     }
 
-    this.logger.log(
-      `Submitting EscrowCreate: buyer=${buyerUser.wallet.address} seller=${sellerUser.wallet.address} amount=${escrow.amountXrp} XRP`,
-    );
-
+    const currency = payment.currency ?? "XRP";
     let txHash: string;
     let sequence: number;
     try {
+      this.logger.log(
+        `Submitting EscrowCreate: buyer=${buyerUser.wallet.address} seller=${sellerUser.wallet.address} amount=${escrow.amountXrp} ${currency}`,
+      );
       ({ txHash, sequence } = await this.xrplService.createEscrow(
         buyerWallet,
         sellerUser.wallet.address,
         escrow.amountXrp,
         condition,
-        payment.currency ?? "XRP",
+        currency,
       ));
     } catch (err) {
       // Case A: XRPL 제출 실패 — 에스크로 미생성 확정, SUBMITTING → PENDING_ESCROW 즉시 복구
       await this.escrowPaymentModel.findOneAndUpdate(
         {
           _id: paymentId,
-          "escrows._id": escrow._id,
-          "escrows.status": "SUBMITTING",
+          escrows: { $elemMatch: { _id: escrow._id, status: "SUBMITTING" } },
         },
         { $set: { "escrows.$.status": "PENDING_ESCROW" } },
       );
       throw err;
     }
 
-    // XRPL 제출 성공 — txHash/sequence를 먼저 로그에 기록해 저장 실패 시에도 복구 단서 보존
-    this.logger.log(`EscrowCreate success: txHash=${txHash} seq=${sequence}`);
-
+    this.logger.log(
+      `Submitting EscrowCreate: buyer=${buyerUser.wallet.address} ` +
+        `seller=${sellerUser.wallet.address} amount=${escrow.amountXrp} ${currency}`,
+    );
     // Case B: post-flight DB 저장 실패 시 최대 3회 재시도 (메모리의 txHash/sequence 활용)
     // 재시도 소진 시 SUBMITTING 유지 → 스케줄러가 XRPL 조회로 복구
     let result: EscrowPaymentDocument | null = null;

--- a/src/modules/escrow-payments/escrow-create.processor.ts
+++ b/src/modules/escrow-payments/escrow-create.processor.ts
@@ -1,29 +1,58 @@
 import { Processor, Process, OnQueueFailed } from "@nestjs/bull";
 import { Logger } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import { Model } from "mongoose";
 import type { Job } from "bull";
 import { EscrowPaymentsService } from "./escrow-payments.service";
 import {
   ESCROW_CREATE_QUEUE,
   EscrowCreateJobData,
 } from "./escrow-create.constants";
+import {
+  EscrowPayment,
+  EscrowPaymentDocument,
+} from "./schemas/escrow-payment.schema";
+import { User, UserDocument } from "../users/schemas/user.schema";
+import { XrplService, XrplWallet } from "../xrpl/xrpl.service";
+import {
+  EscrowItemNotFoundException,
+  EscrowPaymentNotFoundException,
+  InvalidEscrowItemStatusException,
+  PaymentNotActiveException,
+  WalletNotAvailableException,
+} from "../../common/exceptions";
 
-// 재시도해도 해결되지 않는 XRPL 오류 코드 (잔고·금액 관련)
-const AMOUNT_ERROR_CODES = [
+// 재시도해도 해결되지 않는 XRPL 오류 코드
+const NON_RETRYABLE_CODES = [
   "tecUNFUNDED", // 잔고 부족
   "tecINSUF_RESERVE", // reserve 부족
   "temBAD_AMOUNT", // 금액 형식 오류
   "temINSUF_FEE_P", // 수수료 부족
+  "temDISABLED", // amendment 미활성 (XLS-85 미활성 포함)
+  "tecNO_LINE", // trust line 없음 (IOU 에스크로)
+  "tecPATH_DRY", // IOU 경로 없음
+  "tecNO_PERMISSION", // 권한 없음
 ];
 
-function isAmountError(err: Error): boolean {
-  return AMOUNT_ERROR_CODES.some((code) => err.message.includes(code));
+function isNonRetryable(err: Error): boolean {
+  return NON_RETRYABLE_CODES.some((code) => err.message.includes(code));
 }
 
+/**
+ * XRPL 결제요청이 비동기로 들어와 실행됨(Redis MQ)
+ */
 @Processor(ESCROW_CREATE_QUEUE)
 export class EscrowCreateProcessor {
   private readonly logger = new Logger(EscrowCreateProcessor.name);
 
-  constructor(private readonly escrowPaymentsService: EscrowPaymentsService) {}
+  constructor(
+    @InjectModel(EscrowPayment.name)
+    private readonly escrowPaymentModel: Model<EscrowPaymentDocument>,
+    @InjectModel(User.name)
+    private readonly userModel: Model<UserDocument>,
+    private readonly xrplService: XrplService,
+    private readonly escrowPaymentsService: EscrowPaymentsService,
+  ) {}
 
   @Process()
   async handle(job: Job<EscrowCreateJobData>): Promise<void> {
@@ -59,9 +88,9 @@ export class EscrowCreateProcessor {
       }
 
       try {
-        await this.escrowPaymentsService.createXrplEscrow(paymentId, escrowId);
+        await this.createXrplEscrow(paymentId, escrowId);
       } catch (err: any) {
-        if (isAmountError(err)) {
+        if (isNonRetryable(err)) {
           // 잔고/금액 오류 → 재시도해도 해결 안 됨, 즉시 전체 롤백 후 종료
           this.logger.error(
             `EscrowCreate 금액 오류 (재시도 불가): paymentId=${paymentId} escrowId=${escrowId} — ${err.message}`,
@@ -92,5 +121,156 @@ export class EscrowCreateProcessor {
         err.stack,
       );
     }
+  }
+
+  /**
+   * XRPL EscrowCreate 제출 — EscrowItem을 ESCROWED 상태로 전환
+   * 결제가 PROCESSING 상태여야 실행 가능
+   * 모든 에스크로가 ESCROWED 되면 payment → ACTIVE
+   */
+  async createXrplEscrow(
+    paymentId: string,
+    escrowId: string,
+  ): Promise<EscrowPaymentDocument> {
+    const payment = await this.escrowPaymentModel.findById(paymentId);
+    if (!payment) throw new EscrowPaymentNotFoundException();
+
+    if (payment.status !== "PROCESSING") {
+      throw new PaymentNotActiveException(payment.status);
+    }
+
+    const escrow = payment.escrows.find((e) => e._id.toString() === escrowId);
+    if (!escrow) throw new EscrowItemNotFoundException();
+    if (escrow.status !== "PENDING_ESCROW") {
+      throw new InvalidEscrowItemStatusException(
+        "PENDING_ESCROW",
+        escrow.status,
+      );
+    }
+
+    const buyerUser = await this.userModel
+      .findById(payment.buyerId)
+      .select("+wallet.seed");
+    if (!buyerUser?.wallet?.seed) {
+      throw new WalletNotAvailableException("Buyer");
+    }
+
+    const sellerUser = await this.userModel.findById(payment.sellerId);
+    if (!sellerUser?.wallet?.address) {
+      throw new WalletNotAvailableException("Seller");
+    }
+
+    const decryptedSeed = this.xrplService.decrypt(buyerUser.wallet.seed);
+    const buyerWallet: XrplWallet = {
+      address: buyerUser.wallet.address,
+      seed: decryptedSeed,
+      publicKey: buyerUser.wallet.publicKey,
+      privateKey: "",
+    };
+
+    const { condition, fulfillment } =
+      this.xrplService.generateCryptoCondition();
+    const encryptedFulfillment = this.xrplService.encrypt(fulfillment);
+
+    // Pre-flight: PENDING_ESCROW → SUBMITTING + condition/fulfillment 원자적 저장
+    // XRPL 제출 전에 상태를 선점해 재시도 시 중복 EscrowCreate 방지
+    const preFlighted = await this.escrowPaymentModel.findOneAndUpdate(
+      {
+        _id: paymentId,
+        "escrows._id": escrow._id,
+        "escrows.status": "PENDING_ESCROW",
+      },
+      {
+        $set: {
+          "escrows.$.status": "SUBMITTING",
+          "escrows.$.condition": condition,
+          "escrows.$.fulfillment": encryptedFulfillment,
+          "escrows.$.submittingAt": new Date(),
+        },
+      },
+    );
+    if (!preFlighted) {
+      throw new InvalidEscrowItemStatusException(
+        "PENDING_ESCROW",
+        escrow.status,
+      );
+    }
+
+    this.logger.log(
+      `Submitting EscrowCreate: buyer=${buyerUser.wallet.address} seller=${sellerUser.wallet.address} amount=${escrow.amountXrp} XRP`,
+    );
+
+    let txHash: string;
+    let sequence: number;
+    try {
+      ({ txHash, sequence } = await this.xrplService.createEscrow(
+        buyerWallet,
+        sellerUser.wallet.address,
+        escrow.amountXrp,
+        condition,
+        payment.currency ?? "XRP",
+      ));
+    } catch (err) {
+      // Case A: XRPL 제출 실패 — 에스크로 미생성 확정, SUBMITTING → PENDING_ESCROW 즉시 복구
+      await this.escrowPaymentModel.findOneAndUpdate(
+        {
+          _id: paymentId,
+          "escrows._id": escrow._id,
+          "escrows.status": "SUBMITTING",
+        },
+        { $set: { "escrows.$.status": "PENDING_ESCROW" } },
+      );
+      throw err;
+    }
+
+    // XRPL 제출 성공 — txHash/sequence를 먼저 로그에 기록해 저장 실패 시에도 복구 단서 보존
+    this.logger.log(`EscrowCreate success: txHash=${txHash} seq=${sequence}`);
+
+    // Case B: post-flight DB 저장 실패 시 최대 3회 재시도 (메모리의 txHash/sequence 활용)
+    // 재시도 소진 시 SUBMITTING 유지 → 스케줄러가 XRPL 조회로 복구
+    let result: EscrowPaymentDocument | null = null;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        result = await this.escrowPaymentModel.findOneAndUpdate(
+          { _id: paymentId, "escrows._id": escrow._id },
+          {
+            $set: {
+              "escrows.$.status": "ESCROWED",
+              "escrows.$.xrplSequence": sequence,
+              "escrows.$.txHashCreate": txHash,
+              "escrows.$.escrowedAt": new Date(),
+            },
+          },
+          { new: true },
+        );
+        if (result) break;
+        // null 반환 = 다른 경로가 상태를 변경한 경우 (동시성 충돌)
+        if (attempt === 3) {
+          this.logger.error(
+            `Post-flight DB update missed for paymentId=${paymentId} escrowId=${escrow._id.toString()}; recovery scheduler must reconcile via condition lookup`,
+          );
+          throw new Error("Post-flight DB update did not match");
+        }
+        await new Promise((res) => setTimeout(res, attempt * 200));
+      } catch (err: any) {
+        if (attempt === 3) throw err;
+        await new Promise((res) => setTimeout(res, attempt * 200));
+      }
+    }
+
+    const allEscrowed = result!.escrows.every(
+      (e) =>
+        e.status === "ESCROWED" ||
+        e.status === "RELEASED" ||
+        e.status === "CANCELLED",
+    );
+    if (allEscrowed) {
+      await this.escrowPaymentModel.findByIdAndUpdate(paymentId, {
+        $set: { status: "ACTIVE" },
+      });
+      result!.status = "ACTIVE";
+    }
+
+    return result!;
   }
 }

--- a/src/modules/escrow-payments/escrow-payments-crud.service.ts
+++ b/src/modules/escrow-payments/escrow-payments-crud.service.ts
@@ -1,0 +1,111 @@
+import { Injectable } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import { Model, Types } from "mongoose";
+import {
+  EscrowPaymentNotFoundException,
+  UnauthorizedPaymentActionException,
+} from "../../common/exceptions";
+import {
+  EscrowPayment,
+  EscrowPaymentDocument,
+} from "./schemas/escrow-payment.schema";
+import { CreateEscrowPaymentDto } from "./dto/create-escrow-payment.dto";
+import { QueryEscrowPaymentDto } from "./dto/query-escrow-payment.dto";
+
+@Injectable()
+export class EscrowPaymentsCrudService {
+  constructor(
+    @InjectModel(EscrowPayment.name)
+    private readonly escrowPaymentModel: Model<EscrowPaymentDocument>,
+  ) {}
+
+  async create(
+    dto: CreateEscrowPaymentDto,
+    userId: string,
+  ): Promise<EscrowPaymentDocument> {
+    if (userId !== dto.buyerId && userId !== dto.sellerId) {
+      throw new UnauthorizedPaymentActionException();
+    }
+
+    const totalAmountXrp = dto.escrows.reduce((sum, e) => sum + e.amountXrp, 0);
+
+    const doc = new this.escrowPaymentModel({
+      buyerId: new Types.ObjectId(dto.buyerId),
+      sellerId: new Types.ObjectId(dto.sellerId),
+      totalAmountXrp,
+      currency: dto.currency ?? "XRP",
+      memo: dto.memo ?? "",
+      escrows: dto.escrows.map((e) => ({
+        label: e.label,
+        amountXrp: e.amountXrp,
+        order: e.order,
+        requiredEventTypes: e.requiredEventTypes,
+        approvals: e.requiredEventTypes.map((type) => ({
+          eventType: type,
+          buyerApproved: false,
+          sellerApproved: false,
+        })),
+      })),
+    });
+
+    return doc.save();
+  }
+
+  async findAll(
+    userId: string,
+    dto: QueryEscrowPaymentDto,
+  ): Promise<{
+    data: EscrowPaymentDocument[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
+    const { status, group, page = 1, limit = 5 } = dto;
+    const uid = new Types.ObjectId(userId);
+
+    const filter: Record<string, any> = {
+      $or: [{ buyerId: uid }, { sellerId: uid }],
+    };
+
+    if (status) {
+      filter.status = status;
+    } else if (group === "ongoing") {
+      filter.status = {
+        $in: ["DRAFT", "PENDING_APPROVAL", "APPROVED", "PROCESSING", "ACTIVE"],
+      };
+    } else if (group === "done") {
+      filter.status = { $in: ["COMPLETED", "CANCELLED"] };
+    }
+
+    const skip = (page - 1) * limit;
+    const [data, total] = await Promise.all([
+      this.escrowPaymentModel
+        .find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      this.escrowPaymentModel.countDocuments(filter),
+    ]);
+
+    return {
+      data: data as unknown as EscrowPaymentDocument[],
+      total,
+      page,
+      limit,
+    };
+  }
+
+  async findById(id: string, userId: string): Promise<EscrowPaymentDocument> {
+    const doc = await this.escrowPaymentModel.findById(id).lean();
+    if (!doc) throw new EscrowPaymentNotFoundException();
+
+    const isParticipant =
+      doc.buyerId.toString() === userId || doc.sellerId.toString() === userId;
+    if (!isParticipant) {
+      throw new UnauthorizedPaymentActionException();
+    }
+
+    return doc;
+  }
+}

--- a/src/modules/escrow-payments/escrow-payments.controller.ts
+++ b/src/modules/escrow-payments/escrow-payments.controller.ts
@@ -15,6 +15,7 @@ import {
   ApiBody,
   ApiCookieAuth,
 } from "@nestjs/swagger";
+import { EscrowPaymentsCrudService } from "./escrow-payments-crud.service";
 import { EscrowPaymentsService } from "./escrow-payments.service";
 import { CreateEscrowPaymentDto } from "./dto/create-escrow-payment.dto";
 import { QueryEscrowPaymentDto } from "./dto/query-escrow-payment.dto";
@@ -30,7 +31,10 @@ import { ParseMongoIdPipe } from "../../common/pipes/parse-mongo-id.pipe";
 @UseGuards(SessionGuard)
 @Controller("escrow-payments")
 export class EscrowPaymentsController {
-  constructor(private readonly service: EscrowPaymentsService) {}
+  constructor(
+    private readonly crudService: EscrowPaymentsCrudService,
+    private readonly service: EscrowPaymentsService,
+  ) {}
 
   @Get()
   @ApiOperation({
@@ -48,7 +52,7 @@ export class EscrowPaymentsController {
     @Query() query: QueryEscrowPaymentDto,
     @CurrentUser() user: SessionUser,
   ) {
-    return this.service.findAll(user.userId, query);
+    return this.crudService.findAll(user.userId, query);
   }
 
   @Post()
@@ -65,7 +69,7 @@ export class EscrowPaymentsController {
     @Body() dto: CreateEscrowPaymentDto,
     @CurrentUser() user: SessionUser,
   ) {
-    return this.service.create(dto, user.userId);
+    return this.crudService.create(dto, user.userId);
   }
 
   @Get(":id")
@@ -81,7 +85,7 @@ export class EscrowPaymentsController {
     @Param("id", ParseMongoIdPipe) id: string,
     @CurrentUser() user: SessionUser,
   ) {
-    return this.service.findById(id, user.userId);
+    return this.crudService.findById(id, user.userId);
   }
 
   @Post(":id/approve")

--- a/src/modules/escrow-payments/escrow-payments.module.ts
+++ b/src/modules/escrow-payments/escrow-payments.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
 import { BullModule } from "@nestjs/bull";
 import { EscrowPaymentsController } from "./escrow-payments.controller";
+import { EscrowPaymentsCrudService } from "./escrow-payments-crud.service";
 import { EscrowPaymentsService } from "./escrow-payments.service";
 import {
   EscrowPayment,
@@ -27,6 +28,7 @@ import { OutboxModule } from "../outbox/outbox.module";
   ],
   controllers: [EscrowPaymentsController],
   providers: [
+    EscrowPaymentsCrudService,
     EscrowPaymentsService,
     EscrowCreateProcessor,
     EscrowCancelScheduler,

--- a/src/modules/escrow-payments/escrow-payments.service.ts
+++ b/src/modules/escrow-payments/escrow-payments.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
-import { Model, Types } from "mongoose";
+import { Model } from "mongoose";
 import {
   AlreadyApprovedEventException,
   AlreadyApprovedPaymentException,
@@ -9,10 +9,8 @@ import {
   EscrowPaymentNotFoundException,
   EventTypeNotFoundException,
   InvalidEscrowCancelStatusException,
-  InvalidEscrowItemStatusException,
   InvalidPaymentStatusException,
   PaymentInitiationFailedException,
-  PaymentNotActiveException,
   PaymentNotApprovedForPayException,
   UnauthorizedPaymentActionException,
   WalletNotAvailableException,
@@ -23,8 +21,6 @@ import {
   EscrowPaymentDocument,
   EscrowItem,
 } from "./schemas/escrow-payment.schema";
-import { CreateEscrowPaymentDto } from "./dto/create-escrow-payment.dto";
-import { QueryEscrowPaymentDto } from "./dto/query-escrow-payment.dto";
 import { XrplService, XrplWallet } from "../xrpl/xrpl.service";
 import { User, UserDocument } from "../users/schemas/user.schema";
 import { OutboxService } from "../outbox/outbox.service";
@@ -42,98 +38,8 @@ export class EscrowPaymentsService {
     private readonly outboxService: OutboxService,
   ) {}
 
-  async create(
-    dto: CreateEscrowPaymentDto,
-    userId: string,
-  ): Promise<EscrowPaymentDocument> {
-    if (userId !== dto.buyerId && userId !== dto.sellerId) {
-      throw new UnauthorizedPaymentActionException();
-    }
-
-    const totalAmountXrp = dto.escrows.reduce((sum, e) => sum + e.amountXrp, 0);
-
-    const doc = new this.escrowPaymentModel({
-      buyerId: new Types.ObjectId(dto.buyerId),
-      sellerId: new Types.ObjectId(dto.sellerId),
-      totalAmountXrp,
-      memo: dto.memo ?? "",
-      escrows: dto.escrows.map((e) => ({
-        label: e.label,
-        amountXrp: e.amountXrp,
-        order: e.order,
-        requiredEventTypes: e.requiredEventTypes,
-        approvals: e.requiredEventTypes.map((type) => ({
-          eventType: type,
-          buyerApproved: false,
-          sellerApproved: false,
-        })),
-      })),
-    });
-
-    return doc.save();
-  }
-
-  async findAll(
-    userId: string,
-    dto: QueryEscrowPaymentDto,
-  ): Promise<{
-    data: EscrowPaymentDocument[];
-    total: number;
-    page: number;
-    limit: number;
-  }> {
-    const { status, group, page = 1, limit = 5 } = dto;
-    const uid = new Types.ObjectId(userId);
-
-    const filter: Record<string, any> = {
-      $or: [{ buyerId: uid }, { sellerId: uid }],
-    };
-
-    if (status) {
-      filter.status = status;
-    } else if (group === "ongoing") {
-      filter.status = {
-        $in: ["DRAFT", "PENDING_APPROVAL", "APPROVED", "PROCESSING", "ACTIVE"],
-      };
-    } else if (group === "done") {
-      filter.status = { $in: ["COMPLETED", "CANCELLED"] };
-    }
-
-    const skip = (page - 1) * limit;
-    const [data, total] = await Promise.all([
-      this.escrowPaymentModel
-        .find(filter)
-        .sort({ createdAt: -1 })
-        .skip(skip)
-        .limit(limit)
-        .lean(),
-      this.escrowPaymentModel.countDocuments(filter),
-    ]);
-
-    return {
-      data: data as unknown as EscrowPaymentDocument[],
-      total,
-      page,
-      limit,
-    };
-  }
-
-  async findById(id: string, userId: string): Promise<EscrowPaymentDocument> {
-    const doc = await this.escrowPaymentModel.findById(id).lean();
-    if (!doc) throw new EscrowPaymentNotFoundException();
-
-    const isParticipant =
-      doc.buyerId.toString() === userId || doc.sellerId.toString() === userId;
-    if (!isParticipant) {
-      throw new UnauthorizedPaymentActionException();
-    }
-
-    return doc;
-  }
-
   /**
-   * 결제 계획 승인 (buyer / seller 각각 호출)
-   * 양측 모두 승인하면 APPROVED로 전환 — XRPL 실행 없음
+   * 결제 승인 메서드 (buyer가 생성한 결제 내역을 seller가 승인하는 절차)
    */
   async approvePayment(
     paymentId: string,
@@ -174,7 +80,7 @@ export class EscrowPaymentsService {
 
   /**
    * Buyer가 결제 개시 — MongoDB 트랜잭션으로 PROCESSING 상태 전환 + Outbox 이벤트 원자적 기록
-   * 실제 XRPL 처리는 Outbox → Bull Queue → EscrowCreateProcessor가 비동기 수행 (202)
+   * 실제 XRPL 처리는 Outbox → Bull Queue → EscrowCreateProcessor가 비동기 수행
    */
   async initiatePayment(
     paymentId: string,
@@ -197,15 +103,44 @@ export class EscrowPaymentsService {
     );
     const escrowIds = pendingEscrows.map((e) => e._id.toString());
 
-    // 트랜잭션 전 잔고 사전 검증 — 잔고 부족 시 400으로 즉시 반환 (XRPL 연결 불가 시 500)
-    const buyerUser = await this.userModel.findById(payment.buyerId);
+    // RLUSD는 TrustSet 서명에 seed 필요 → +wallet.seed 포함 조회
+    const withSeed = payment.currency === "RLUSD";
+    const [buyerUser, sellerUser] = await Promise.all([
+      this.userModel
+        .findById(payment.buyerId)
+        .select(withSeed ? "+wallet.seed" : ""),
+      this.userModel
+        .findById(payment.sellerId)
+        .select(withSeed ? "+wallet.seed" : ""),
+    ]);
     if (!buyerUser?.wallet?.address) {
       throw new WalletNotAvailableException("Buyer");
     }
-    await this.xrplService.validateEscrowFunds(
-      buyerUser.wallet.address,
-      pendingEscrows,
-    );
+
+    if (payment.currency === "RLUSD") {
+      if (!sellerUser?.wallet?.address || !sellerUser.wallet.seed) {
+        throw new WalletNotAvailableException("Seller");
+      }
+      await Promise.all([
+        this.xrplService.ensureRlusdTrustLine(
+          buyerUser.wallet.address,
+          buyerUser.wallet.seed,
+        ),
+        this.xrplService.ensureRlusdTrustLine(
+          sellerUser.wallet.address,
+          sellerUser.wallet.seed,
+        ),
+      ]);
+      await this.xrplService.validateRlusdFunds(
+        buyerUser.wallet.address,
+        pendingEscrows,
+      );
+    } else {
+      await this.xrplService.validateEscrowFunds(
+        buyerUser.wallet.address,
+        pendingEscrows,
+      );
+    }
 
     let initiated: EscrowPaymentDocument | null = null;
     const session = await this.escrowPaymentModel.db.startSession();
@@ -241,158 +176,8 @@ export class EscrowPaymentsService {
   }
 
   /**
-   * XRPL EscrowCreate 제출 — EscrowItem을 ESCROWED 상태로 전환
-   * 결제가 PROCESSING 상태여야 실행 가능
-   * 모든 에스크로가 ESCROWED 되면 payment → ACTIVE
-   */
-  async createXrplEscrow(
-    paymentId: string,
-    escrowId: string,
-  ): Promise<EscrowPaymentDocument> {
-    const payment = await this.escrowPaymentModel.findById(paymentId);
-    if (!payment) throw new EscrowPaymentNotFoundException();
-
-    if (payment.status !== "PROCESSING") {
-      throw new PaymentNotActiveException(payment.status);
-    }
-
-    const escrow = payment.escrows.find((e) => e._id.toString() === escrowId);
-    if (!escrow) throw new EscrowItemNotFoundException();
-    if (escrow.status !== "PENDING_ESCROW") {
-      throw new InvalidEscrowItemStatusException(
-        "PENDING_ESCROW",
-        escrow.status,
-      );
-    }
-
-    const buyerUser = await this.userModel
-      .findById(payment.buyerId)
-      .select("+wallet.seed");
-    if (!buyerUser?.wallet?.seed) {
-      throw new WalletNotAvailableException("Buyer");
-    }
-
-    const sellerUser = await this.userModel.findById(payment.sellerId);
-    if (!sellerUser?.wallet?.address) {
-      throw new WalletNotAvailableException("Seller");
-    }
-
-    const decryptedSeed = this.xrplService.decrypt(buyerUser.wallet.seed);
-    const buyerWallet: XrplWallet = {
-      address: buyerUser.wallet.address,
-      seed: decryptedSeed,
-      publicKey: buyerUser.wallet.publicKey,
-      privateKey: "",
-    };
-
-    const { condition, fulfillment } =
-      this.xrplService.generateCryptoCondition();
-    const encryptedFulfillment = this.xrplService.encrypt(fulfillment);
-
-    // Pre-flight: PENDING_ESCROW → SUBMITTING + condition/fulfillment 원자적 저장
-    // XRPL 제출 전에 상태를 선점해 재시도 시 중복 EscrowCreate 방지
-    const preFlighted = await this.escrowPaymentModel.findOneAndUpdate(
-      {
-        _id: paymentId,
-        "escrows._id": escrow._id,
-        "escrows.status": "PENDING_ESCROW",
-      },
-      {
-        $set: {
-          "escrows.$.status": "SUBMITTING",
-          "escrows.$.condition": condition,
-          "escrows.$.fulfillment": encryptedFulfillment,
-          "escrows.$.submittingAt": new Date(),
-        },
-      },
-    );
-    if (!preFlighted) {
-      throw new InvalidEscrowItemStatusException(
-        "PENDING_ESCROW",
-        escrow.status,
-      );
-    }
-
-    this.logger.log(
-      `Submitting EscrowCreate: buyer=${buyerUser.wallet.address} seller=${sellerUser.wallet.address} amount=${escrow.amountXrp} XRP`,
-    );
-
-    let txHash: string;
-    let sequence: number;
-    try {
-      ({ txHash, sequence } = await this.xrplService.createEscrow(
-        buyerWallet,
-        sellerUser.wallet.address,
-        escrow.amountXrp,
-        condition,
-      ));
-    } catch (err) {
-      // Case A: XRPL 제출 실패 — 에스크로 미생성 확정, SUBMITTING → PENDING_ESCROW 즉시 복구
-      await this.escrowPaymentModel.findOneAndUpdate(
-        {
-          _id: paymentId,
-          "escrows._id": escrow._id,
-          "escrows.status": "SUBMITTING",
-        },
-        { $set: { "escrows.$.status": "PENDING_ESCROW" } },
-      );
-      throw err;
-    }
-
-    // XRPL 제출 성공 — txHash/sequence를 먼저 로그에 기록해 저장 실패 시에도 복구 단서 보존
-    this.logger.log(`EscrowCreate success: txHash=${txHash} seq=${sequence}`);
-
-    // Case B: post-flight DB 저장 실패 시 최대 3회 재시도 (메모리의 txHash/sequence 활용)
-    // 재시도 소진 시 SUBMITTING 유지 → 스케줄러가 XRPL 조회로 복구
-    let result: EscrowPaymentDocument | null = null;
-    for (let attempt = 1; attempt <= 3; attempt++) {
-      try {
-        result = await this.escrowPaymentModel.findOneAndUpdate(
-          { _id: paymentId, "escrows._id": escrow._id },
-          {
-            $set: {
-              "escrows.$.status": "ESCROWED",
-              "escrows.$.xrplSequence": sequence,
-              "escrows.$.txHashCreate": txHash,
-              "escrows.$.escrowedAt": new Date(),
-            },
-          },
-          { new: true },
-        );
-        if (result) break;
-        // null 반환 = 다른 경로가 상태를 변경한 경우 (동시성 충돌)
-        if (attempt === 3) {
-          this.logger.error(
-            `Post-flight DB update missed for paymentId=${paymentId} escrowId=${escrow._id.toString()}; recovery scheduler must reconcile via condition lookup`,
-          );
-          throw new Error("Post-flight DB update did not match");
-        }
-        await new Promise((res) => setTimeout(res, attempt * 200));
-      } catch (err: any) {
-        if (attempt === 3) throw err;
-        await new Promise((res) => setTimeout(res, attempt * 200));
-      }
-    }
-
-    const allEscrowed = result!.escrows.every(
-      (e) =>
-        e.status === "ESCROWED" ||
-        e.status === "RELEASED" ||
-        e.status === "CANCELLED",
-    );
-    if (allEscrowed) {
-      await this.escrowPaymentModel.findByIdAndUpdate(paymentId, {
-        $set: { status: "ACTIVE" },
-      });
-      result!.status = "ACTIVE";
-    }
-
-    return result!;
-  }
-
-  /**
-   * 에스크로 전체 롤백 — 재시도 소진 후 EscrowCreateProcessor가 호출
-   * PENDING_ESCROW → CANCELLED, ESCROWED → CANCELLING (XRPL CancelAfter 대기)
+   * 에스크로 전체 롤백 — EscrowCreateProcessor / EscrowSubmitRecoveryScheduler에서 호출
+   * PENDING_ESCROW → CANCELLED, ESCROWED/SUBMITTING → CANCELLING
    */
   async rollbackAllEscrows(paymentId: string): Promise<void> {
     const payment = await this.escrowPaymentModel.findById(paymentId);
@@ -401,7 +186,7 @@ export class EscrowPaymentsService {
       return;
     }
 
-    if (payment.status === "CANCELLED") return; // 멱등 처리
+    if (payment.status === "CANCELLED") return;
 
     for (const escrow of payment.escrows) {
       if (escrow.status === "PENDING_ESCROW") {
@@ -410,7 +195,6 @@ export class EscrowPaymentsService {
         escrow.status === "ESCROWED" ||
         escrow.status === "SUBMITTING"
       ) {
-        // SUBMITTING: XRPL 제출 여부 불명 — 제출됐을 경우를 대비해 CANCELLING으로 처리
         escrow.status = "CANCELLING";
       }
     }
@@ -535,7 +319,7 @@ export class EscrowPaymentsService {
       this.logger.log(`EscrowFinish success: txHash=${txHash}`);
     } catch (err: any) {
       this.logger.error(`EscrowFinish failed: ${err.message}`, err.stack);
-      escrow.status = "ESCROWED"; // 롤백
+      escrow.status = "ESCROWED";
       await payment.save();
       throw err;
     }
@@ -570,78 +354,5 @@ export class EscrowPaymentsService {
     if (!escrow) throw new EscrowItemNotFoundException();
 
     return escrow;
-  }
-
-  /**
-   * SUBMITTING 에스크로 복구 — EscrowSubmitRecoveryScheduler에서 호출
-   * XRPL 조회 결과에 따라 ESCROWED 복구 또는 결제 전체 취소
-   */
-  async recoverSubmittingEscrow(
-    paymentId: string,
-    escrowId: string,
-    buyerAddress: string,
-  ): Promise<"recovered" | "cancelled"> {
-    const escrow = await this.getEscrowStatus(paymentId, escrowId);
-    if (escrow.status !== "SUBMITTING") return "recovered"; // 이미 다른 경로로 처리됨
-
-    if (!escrow.condition) {
-      // condition 미저장 = pre-flight 전에 프로세스 종료 → XRPL 제출 안 됨
-      await this.cancelSubmittingEscrowAndRollback(paymentId, escrowId);
-      return "cancelled";
-    }
-
-    const xrplResult = await this.xrplService.findEscrowByCondition(
-      buyerAddress,
-      escrow.condition,
-    );
-
-    if (xrplResult) {
-      // XRPL에 에스크로 존재 → DB만 업데이트하면 복구 완료
-      const result = await this.escrowPaymentModel.findOneAndUpdate(
-        { _id: paymentId, "escrows._id": new Types.ObjectId(escrowId) },
-        {
-          $set: {
-            "escrows.$.status": "ESCROWED",
-            "escrows.$.xrplSequence": xrplResult.sequence,
-            "escrows.$.txHashCreate": xrplResult.txHash,
-            "escrows.$.escrowedAt": new Date(),
-          },
-        },
-        { new: true },
-      );
-      const allEscrowed = result!.escrows.every(
-        (e) =>
-          e.status === "ESCROWED" ||
-          e.status === "RELEASED" ||
-          e.status === "CANCELLED",
-      );
-      if (allEscrowed) {
-        await this.escrowPaymentModel.findByIdAndUpdate(paymentId, {
-          $set: { status: "ACTIVE" },
-        });
-      }
-      return "recovered";
-    }
-
-    // XRPL에 에스크로 없음 → 제출 실패 확정 → 결제 취소
-    await this.cancelSubmittingEscrowAndRollback(paymentId, escrowId);
-    return "cancelled";
-  }
-
-  private async cancelSubmittingEscrowAndRollback(
-    paymentId: string,
-    escrowId: string,
-  ): Promise<void> {
-    // XRPL에 없음이 확정된 SUBMITTING 에스크로를 CANCELLED로 직접 전환
-    // (rollbackAllEscrows는 SUBMITTING → CANCELLING으로 처리하므로 별도 처리)
-    await this.escrowPaymentModel.findOneAndUpdate(
-      {
-        _id: paymentId,
-        "escrows._id": new Types.ObjectId(escrowId),
-        "escrows.status": "SUBMITTING",
-      },
-      { $set: { "escrows.$.status": "CANCELLED" } },
-    );
-    await this.rollbackAllEscrows(paymentId);
   }
 }

--- a/src/modules/escrow-payments/escrow-submit-recovery.scheduler.ts
+++ b/src/modules/escrow-payments/escrow-submit-recovery.scheduler.ts
@@ -110,6 +110,7 @@ export class EscrowSubmitRecoveryScheduler {
       return "cancelled";
     }
 
+    // XRPL 서버에 접속하여 sequence, txHash 를 가져옴
     const xrplResult = await this.xrplService.findEscrowByCondition(
       buyerAddress,
       escrow.condition,
@@ -118,7 +119,15 @@ export class EscrowSubmitRecoveryScheduler {
     if (xrplResult) {
       // XRPL에 에스크로 존재 → DB만 업데이트하면 복구 완료
       const result = await this.escrowPaymentModel.findOneAndUpdate(
-        { _id: paymentId, "escrows._id": new Types.ObjectId(escrowId) },
+        {
+          _id: paymentId,
+          escrows: {
+            $elemMatch: {
+              _id: new Types.ObjectId(escrowId),
+              status: "SUBMITTING",
+            },
+          },
+        },
         {
           $set: {
             "escrows.$.status": "ESCROWED",
@@ -129,7 +138,9 @@ export class EscrowSubmitRecoveryScheduler {
         },
         { new: true },
       );
-      const allEscrowed = result!.escrows.every(
+      if (!result) return "recovered";
+
+      const allEscrowed = result.escrows.every(
         (e) =>
           e.status === "ESCROWED" ||
           e.status === "RELEASED" ||

--- a/src/modules/escrow-payments/escrow-submit-recovery.scheduler.ts
+++ b/src/modules/escrow-payments/escrow-submit-recovery.scheduler.ts
@@ -1,13 +1,14 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { Cron, CronExpression } from "@nestjs/schedule";
 import { InjectModel } from "@nestjs/mongoose";
-import { Model } from "mongoose";
+import { Model, Types } from "mongoose";
 import {
   EscrowPayment,
   EscrowPaymentDocument,
 } from "./schemas/escrow-payment.schema";
 import { User, UserDocument } from "../users/schemas/user.schema";
 import { EscrowPaymentsService } from "./escrow-payments.service";
+import { XrplService } from "../xrpl/xrpl.service";
 
 // 이 시간보다 오래된 SUBMITTING만 처리 — 정상 진행 중인 요청과 구분
 const SUBMITTING_TIMEOUT_MS = 5 * 60 * 1000;
@@ -21,6 +22,7 @@ export class EscrowSubmitRecoveryScheduler {
     private readonly escrowPaymentModel: Model<EscrowPaymentDocument>,
     @InjectModel(User.name)
     private readonly userModel: Model<UserDocument>,
+    private readonly xrplService: XrplService,
     private readonly escrowPaymentsService: EscrowPaymentsService,
   ) {}
 
@@ -64,12 +66,11 @@ export class EscrowSubmitRecoveryScheduler {
         const paymentId = payment._id.toString();
         const escrowId = escrow._id.toString();
         try {
-          const outcome =
-            await this.escrowPaymentsService.recoverSubmittingEscrow(
-              paymentId,
-              escrowId,
-              buyerUser.wallet.address,
-            );
+          const outcome = await this.recoverSubmittingEscrow(
+            paymentId,
+            escrowId,
+            buyerUser.wallet.address,
+          );
           if (outcome === "recovered") {
             this.logger.log(
               `Recovered SUBMITTING escrow: paymentId=${paymentId} escrowId=${escrowId}`,
@@ -87,5 +88,80 @@ export class EscrowSubmitRecoveryScheduler {
         }
       }
     }
+  }
+
+  /**
+   * SUBMITTING 에스크로 복구 — XRPL 조회 결과에 따라 ESCROWED 복구 또는 결제 전체 취소
+   */
+  async recoverSubmittingEscrow(
+    paymentId: string,
+    escrowId: string,
+    buyerAddress: string,
+  ): Promise<"recovered" | "cancelled"> {
+    const escrow = await this.escrowPaymentsService.getEscrowStatus(
+      paymentId,
+      escrowId,
+    );
+    if (escrow.status !== "SUBMITTING") return "recovered"; // 이미 다른 경로로 처리됨
+
+    if (!escrow.condition) {
+      // condition 미저장 = pre-flight 전에 프로세스 종료 → XRPL 제출 안 됨
+      await this.cancelSubmittingEscrowAndRollback(paymentId, escrowId);
+      return "cancelled";
+    }
+
+    const xrplResult = await this.xrplService.findEscrowByCondition(
+      buyerAddress,
+      escrow.condition,
+    );
+
+    if (xrplResult) {
+      // XRPL에 에스크로 존재 → DB만 업데이트하면 복구 완료
+      const result = await this.escrowPaymentModel.findOneAndUpdate(
+        { _id: paymentId, "escrows._id": new Types.ObjectId(escrowId) },
+        {
+          $set: {
+            "escrows.$.status": "ESCROWED",
+            "escrows.$.xrplSequence": xrplResult.sequence,
+            "escrows.$.txHashCreate": xrplResult.txHash,
+            "escrows.$.escrowedAt": new Date(),
+          },
+        },
+        { new: true },
+      );
+      const allEscrowed = result!.escrows.every(
+        (e) =>
+          e.status === "ESCROWED" ||
+          e.status === "RELEASED" ||
+          e.status === "CANCELLED",
+      );
+      if (allEscrowed) {
+        await this.escrowPaymentModel.findByIdAndUpdate(paymentId, {
+          $set: { status: "ACTIVE" },
+        });
+      }
+      return "recovered";
+    }
+
+    // XRPL에 에스크로 없음 → 제출 실패 확정 → 결제 취소
+    await this.cancelSubmittingEscrowAndRollback(paymentId, escrowId);
+    return "cancelled";
+  }
+
+  private async cancelSubmittingEscrowAndRollback(
+    paymentId: string,
+    escrowId: string,
+  ): Promise<void> {
+    // XRPL에 없음이 확정된 SUBMITTING 에스크로를 CANCELLED로 직접 전환
+    // (rollbackAllEscrows는 SUBMITTING → CANCELLING으로 처리하므로 별도 처리)
+    await this.escrowPaymentModel.findOneAndUpdate(
+      {
+        _id: paymentId,
+        "escrows._id": new Types.ObjectId(escrowId),
+        "escrows.status": "SUBMITTING",
+      },
+      { $set: { "escrows.$.status": "CANCELLED" } },
+    );
+    await this.escrowPaymentsService.rollbackAllEscrows(paymentId);
   }
 }

--- a/src/modules/escrow-payments/schemas/escrow-payment.schema.ts
+++ b/src/modules/escrow-payments/schemas/escrow-payment.schema.ts
@@ -70,6 +70,8 @@ export class EscrowItem {
 
 export const EscrowItemSchema = SchemaFactory.createForClass(EscrowItem);
 
+export type EscrowCurrency = "XRP" | "RLUSD";
+
 @Schema({ timestamps: true })
 export class EscrowPayment {
   @Prop({ type: Types.ObjectId, ref: "User", required: true, index: true })
@@ -79,6 +81,9 @@ export class EscrowPayment {
   sellerId: Types.ObjectId;
 
   @Prop({ required: true, min: 0 }) totalAmountXrp: number;
+
+  @Prop({ type: String, enum: ["XRP", "RLUSD"], default: "XRP" })
+  currency: EscrowCurrency;
 
   @Prop({
     type: String,

--- a/src/modules/xrpl/xrpl.service.spec.ts
+++ b/src/modules/xrpl/xrpl.service.spec.ts
@@ -1,21 +1,36 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { ConfigService } from "@nestjs/config";
+import * as xrpl from "xrpl";
 import { XrplService } from "./xrpl.service";
-import { InsufficientXrpBalanceException } from "../../common/exceptions";
+import {
+  InsufficientXrpBalanceException,
+  XrplTransactionFailedException,
+} from "../../common/exceptions";
 
 // ── 공통 픽스처 ────────────────────────────────────────────────────────────────
 
 const BUYER_ADDRESS = "rBuyerAddress123";
+const SELLER_ADDRESS = "rSellerAddress456";
+const TEST_ISSUER = "rIssuerAddress789";
 const ENCRYPTION_KEY = "a".repeat(64); // 유효한 64자리 hex (테스트용)
+const TEST_CURRENCY = "TISD";
 
 function makeConfigService(overrides: Record<string, string> = {}) {
   const defaults: Record<string, string> = {
     "xrpl.wsUrl": "wss://s.altnet.rippletest.net:51233",
     "xrpl.destAddress": "rDestAddress",
+    "xrpl.issuerAddress": TEST_ISSUER,
+    "xrpl.issuedCurrencyCode": TEST_CURRENCY,
     "security.encryptionKey": ENCRYPTION_KEY,
     ...overrides,
   };
   return { get: (key: string) => defaults[key] };
+}
+
+function makeAccountLines(
+  lines: { currency: string; account: string; balance?: string }[],
+) {
+  return { result: { lines } };
 }
 
 // account_info + server_info 응답 픽스처
@@ -49,6 +64,8 @@ describe("XrplService", () => {
   let service: XrplService;
   let mockClient: {
     request: jest.Mock;
+    autofill: jest.Mock;
+    submitAndWait: jest.Mock;
     isConnected: jest.Mock;
     connect: jest.Mock;
   };
@@ -56,6 +73,10 @@ describe("XrplService", () => {
   beforeEach(async () => {
     mockClient = {
       request: jest.fn(),
+      autofill: jest.fn().mockResolvedValue({ TransactionType: "mock" }),
+      submitAndWait: jest.fn().mockResolvedValue({
+        result: { hash: "ABCD1234", meta: { TransactionResult: "tesSUCCESS" } },
+      }),
       isConnected: jest.fn().mockReturnValue(true),
       connect: jest.fn().mockResolvedValue(undefined),
     };
@@ -193,6 +214,212 @@ describe("XrplService", () => {
       await expect(
         service.validateEscrowFunds(BUYER_ADDRESS, [{ amountXrp: 300 }]),
       ).rejects.toThrow(InsufficientXrpBalanceException);
+    });
+  });
+
+  // ── ensureRlusdTrustLine ──────────────────────────────────────────────────
+
+  describe("ensureRlusdTrustLine", () => {
+    // decrypt는 실제 AES 키가 맞아야 동작하므로 spy로 대체
+    // Wallet.fromSeed + sign도 네트워크 불필요하지만 서명 검증 없이 tx_blob만 필요하므로 mock
+    let walletSignSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      jest
+        .spyOn(service as any, "decrypt")
+        .mockReturnValue("sEdSomeFakeSeedForTest");
+
+      walletSignSpy = jest.spyOn(xrpl.Wallet, "fromSeed").mockReturnValue({
+        sign: jest
+          .fn()
+          .mockReturnValue({ tx_blob: "MOCKTXBLOB", hash: "MOCKHASH" }),
+      } as any);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("trust line이 이미 있으면 TrustSet 제출 안 함", async () => {
+      mockClient.request.mockResolvedValue(
+        makeAccountLines([
+          { currency: TEST_CURRENCY, account: TEST_ISSUER, balance: "1000" },
+        ]),
+      );
+
+      await service.ensureRlusdTrustLine(BUYER_ADDRESS, "encrypted-seed");
+
+      expect(mockClient.submitAndWait).not.toHaveBeenCalled();
+    });
+
+    it("trust line 없으면 TrustSet 제출", async () => {
+      mockClient.request.mockResolvedValue(makeAccountLines([]));
+
+      await service.ensureRlusdTrustLine(BUYER_ADDRESS, "encrypted-seed");
+
+      expect(mockClient.autofill).toHaveBeenCalledWith(
+        expect.objectContaining({
+          TransactionType: "TrustSet",
+          Account: BUYER_ADDRESS,
+          LimitAmount: expect.objectContaining({
+            currency: TEST_CURRENCY,
+            issuer: TEST_ISSUER,
+          }),
+        }),
+      );
+      expect(mockClient.submitAndWait).toHaveBeenCalledWith("MOCKTXBLOB");
+    });
+
+    it("다른 issuer의 동일 currency가 있어도 TrustSet 제출", async () => {
+      mockClient.request.mockResolvedValue(
+        makeAccountLines([
+          { currency: TEST_CURRENCY, account: "rOtherIssuer", balance: "500" },
+        ]),
+      );
+
+      await service.ensureRlusdTrustLine(BUYER_ADDRESS, "encrypted-seed");
+
+      expect(mockClient.submitAndWait).toHaveBeenCalled();
+    });
+
+    it("TrustSet 실패(tesSUCCESS 아님) → XrplTransactionFailedException", async () => {
+      mockClient.request.mockResolvedValue(makeAccountLines([]));
+      mockClient.submitAndWait.mockResolvedValue({
+        result: {
+          hash: "FAIL",
+          meta: { TransactionResult: "tecINSUFFICIENT_RESERVE" },
+        },
+      });
+
+      await expect(
+        service.ensureRlusdTrustLine(BUYER_ADDRESS, "encrypted-seed"),
+      ).rejects.toThrow(XrplTransactionFailedException);
+
+      expect(walletSignSpy).toHaveBeenCalled();
+    });
+  });
+
+  // ── validateRlusdFunds ────────────────────────────────────────────────────
+
+  describe("validateRlusdFunds", () => {
+    it("잔고 충분 → 예외 없이 통과", async () => {
+      mockClient.request.mockResolvedValue(
+        makeAccountLines([
+          { currency: TEST_CURRENCY, account: TEST_ISSUER, balance: "1000" },
+        ]),
+      );
+
+      await expect(
+        service.validateRlusdFunds(BUYER_ADDRESS, [
+          { amountXrp: 500 },
+          { amountXrp: 300 },
+        ]),
+      ).resolves.toBeUndefined();
+    });
+
+    it("잔고 부족 → InsufficientXrpBalanceException", async () => {
+      mockClient.request.mockResolvedValue(
+        makeAccountLines([
+          { currency: TEST_CURRENCY, account: TEST_ISSUER, balance: "200" },
+        ]),
+      );
+
+      await expect(
+        service.validateRlusdFunds(BUYER_ADDRESS, [{ amountXrp: 500 }]),
+      ).rejects.toThrow(InsufficientXrpBalanceException);
+    });
+
+    it("trust line 없으면 잔고 0으로 간주 → InsufficientXrpBalanceException", async () => {
+      mockClient.request.mockResolvedValue(makeAccountLines([]));
+
+      await expect(
+        service.validateRlusdFunds(BUYER_ADDRESS, [{ amountXrp: 1 }]),
+      ).rejects.toThrow(InsufficientXrpBalanceException);
+    });
+
+    it("다른 issuer의 잔고는 집계 안 함", async () => {
+      mockClient.request.mockResolvedValue(
+        makeAccountLines([
+          { currency: TEST_CURRENCY, account: "rOtherIssuer", balance: "9999" },
+        ]),
+      );
+
+      await expect(
+        service.validateRlusdFunds(BUYER_ADDRESS, [{ amountXrp: 1 }]),
+      ).rejects.toThrow(InsufficientXrpBalanceException);
+    });
+
+    it("잔고와 required가 정확히 같으면 통과", async () => {
+      mockClient.request.mockResolvedValue(
+        makeAccountLines([
+          { currency: TEST_CURRENCY, account: TEST_ISSUER, balance: "300" },
+        ]),
+      );
+
+      await expect(
+        service.validateRlusdFunds(BUYER_ADDRESS, [
+          { amountXrp: 100 },
+          { amountXrp: 200 },
+        ]),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // ── sendIssuedCurrencyPayment ─────────────────────────────────────────────
+
+  describe("sendIssuedCurrencyPayment", () => {
+    const senderWallet = {
+      address: SELLER_ADDRESS,
+      seed: "sEdSomeFakeSeedForTest",
+      publicKey: "",
+      privateKey: "",
+    };
+
+    beforeEach(() => {
+      jest.spyOn(xrpl.Wallet, "fromSeed").mockReturnValue({
+        sign: jest
+          .fn()
+          .mockReturnValue({ tx_blob: "MOCKTXBLOB", hash: "MOCKHASH" }),
+      } as any);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("성공 → txHash 반환", async () => {
+      const txHash = await service.sendIssuedCurrencyPayment(
+        senderWallet,
+        BUYER_ADDRESS,
+        "500",
+      );
+
+      expect(txHash).toBe("ABCD1234");
+      expect(mockClient.autofill).toHaveBeenCalledWith(
+        expect.objectContaining({
+          TransactionType: "Payment",
+          Account: SELLER_ADDRESS,
+          Destination: BUYER_ADDRESS,
+          Amount: expect.objectContaining({
+            currency: TEST_CURRENCY,
+            issuer: TEST_ISSUER,
+            value: "500",
+          }),
+        }),
+      );
+    });
+
+    it("Payment 실패 → XrplTransactionFailedException", async () => {
+      mockClient.submitAndWait.mockResolvedValue({
+        result: {
+          hash: "FAIL",
+          meta: { TransactionResult: "tecPATH_DRY" },
+        },
+      });
+
+      await expect(
+        service.sendIssuedCurrencyPayment(senderWallet, BUYER_ADDRESS, "500"),
+      ).rejects.toThrow(XrplTransactionFailedException);
     });
   });
 });

--- a/src/modules/xrpl/xrpl.service.spec.ts
+++ b/src/modules/xrpl/xrpl.service.spec.ts
@@ -4,6 +4,7 @@ import * as xrpl from "xrpl";
 import { XrplService } from "./xrpl.service";
 import {
   InsufficientXrpBalanceException,
+  InsufficientRlusdBalanceException,
   XrplTransactionFailedException,
 } from "../../common/exceptions";
 
@@ -317,7 +318,7 @@ describe("XrplService", () => {
       ).resolves.toBeUndefined();
     });
 
-    it("잔고 부족 → InsufficientXrpBalanceException", async () => {
+    it("잔고 부족 → InsufficientRlusdBalanceException", async () => {
       mockClient.request.mockResolvedValue(
         makeAccountLines([
           { currency: TEST_CURRENCY, account: TEST_ISSUER, balance: "200" },
@@ -326,15 +327,15 @@ describe("XrplService", () => {
 
       await expect(
         service.validateRlusdFunds(BUYER_ADDRESS, [{ amountXrp: 500 }]),
-      ).rejects.toThrow(InsufficientXrpBalanceException);
+      ).rejects.toThrow(InsufficientRlusdBalanceException);
     });
 
-    it("trust line 없으면 잔고 0으로 간주 → InsufficientXrpBalanceException", async () => {
+    it("trust line 없으면 잔고 0으로 간주 → InsufficientRlusdBalanceException", async () => {
       mockClient.request.mockResolvedValue(makeAccountLines([]));
 
       await expect(
         service.validateRlusdFunds(BUYER_ADDRESS, [{ amountXrp: 1 }]),
-      ).rejects.toThrow(InsufficientXrpBalanceException);
+      ).rejects.toThrow(InsufficientRlusdBalanceException);
     });
 
     it("다른 issuer의 잔고는 집계 안 함", async () => {
@@ -346,7 +347,7 @@ describe("XrplService", () => {
 
       await expect(
         service.validateRlusdFunds(BUYER_ADDRESS, [{ amountXrp: 1 }]),
-      ).rejects.toThrow(InsufficientXrpBalanceException);
+      ).rejects.toThrow(InsufficientRlusdBalanceException);
     });
 
     it("잔고와 required가 정확히 같으면 통과", async () => {

--- a/src/modules/xrpl/xrpl.service.ts
+++ b/src/modules/xrpl/xrpl.service.ts
@@ -659,7 +659,7 @@ export class XrplService implements OnModuleInit, OnModuleDestroy {
       return xrpToDrops(amount);
     }
     return {
-      value: new BigNumber(amount).toFixed(),
+      value: amount.toFixed(6),
       currency: this.iouCurrencyCode,
       issuer: this.iouIssuer,
     };

--- a/src/modules/xrpl/xrpl.service.ts
+++ b/src/modules/xrpl/xrpl.service.ts
@@ -49,6 +49,8 @@ export class XrplService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(XrplService.name);
   private readonly wsUrl: string;
   private readonly destAddress: string;
+  private readonly iouIssuer: string;
+  private readonly iouCurrencyCode: string;
   private readonly encryptionKey: Buffer; // AES-256용 32바이트 키
   private client: Client;
   private connectPromise?: Promise<void>;
@@ -56,6 +58,13 @@ export class XrplService implements OnModuleInit, OnModuleDestroy {
   constructor(private readonly config: ConfigService) {
     this.wsUrl = this.config.get<string>("xrpl.wsUrl")!;
     this.destAddress = this.config.get<string>("xrpl.destAddress")!;
+    const issuerAddress = this.config.get<string>("xrpl.issuerAddress");
+    if (!issuerAddress) {
+      throw new Error("XRPL_ISSUER_ADDRESS is not configured");
+    }
+    this.iouIssuer = issuerAddress;
+    this.iouCurrencyCode =
+      this.config.get<string>("xrpl.issuedCurrencyCode") || "RLUSD";
 
     const keyStr = this.config.get<string>("security.encryptionKey");
     if (!keyStr || !/^[0-9a-fA-F]{64}$/.test(keyStr)) {
@@ -206,8 +215,9 @@ export class XrplService implements OnModuleInit, OnModuleDestroy {
   async createEscrow(
     buyerWallet: XrplWallet,
     sellerAddress: string,
-    amountXrp: number,
+    amount: number,
     condition: string,
+    currency: "XRP" | "RLUSD" = "XRP",
   ): Promise<{ txHash: string; sequence: number }> {
     await this.connect();
     const wallet = Wallet.fromSeed(buyerWallet.seed);
@@ -220,7 +230,7 @@ export class XrplService implements OnModuleInit, OnModuleDestroy {
     const tx: EscrowCreate = {
       TransactionType: "EscrowCreate",
       Account: wallet.address,
-      Amount: xrpToDrops(amountXrp),
+      Amount: this.buildEscrowAmount(currency, amount),
       Destination: sellerAddress,
       Condition: condition,
       CancelAfter: cancelAfter,
@@ -478,5 +488,177 @@ export class XrplService implements OnModuleInit, OnModuleDestroy {
     this.logger.log(
       `Balance check OK: ${balanceDrops} drops available, ${requiredDrops} drops required`,
     );
+  }
+
+  /**
+   * issuer 계정에 AllowTrustLineLocking 플래그 설정 (asfAllowTrustLineLocking = 17)
+   * XLS-85 TokenEscrow: issuer가 이 플래그를 보유해야 IOU EscrowCreate 허용
+   * 미설정 시 EscrowCreate 제출 시 tecNO_PERMISSION 반환
+   */
+  async enableTrustLineLocking(issuerWallet: XrplWallet): Promise<void> {
+    await this.connect();
+    const wallet = Wallet.fromSeed(issuerWallet.seed);
+    const tx = {
+      TransactionType: "AccountSet" as const,
+      Account: issuerWallet.address,
+      SetFlag: 17, // asfAllowTrustLineLocking
+    };
+    const prepared = await this.client.autofill(tx);
+    const { tx_blob } = wallet.sign(prepared);
+    const result = await this.client.submitAndWait(tx_blob);
+
+    const meta = result.result.meta as any;
+    if (meta?.TransactionResult !== "tesSUCCESS") {
+      throw new XrplTransactionFailedException(
+        "AccountSet:AllowTrustLineLocking",
+        meta?.TransactionResult ?? "unknown",
+      );
+    }
+
+    this.logger.log(
+      `AllowTrustLineLocking enabled for ${issuerWallet.address}`,
+    );
+  }
+
+  /**
+   * RLUSD trust line이 없으면 TrustSet 트랜잭션으로 생성
+   * 결제 생성(initiatePayment) pre-flight에서 buyer/seller 양측 호출
+   */
+  async ensureRlusdTrustLine(
+    address: string,
+    encryptedSeed: string,
+  ): Promise<void> {
+    await this.connect();
+
+    const resp = await this.client.request({
+      command: "account_lines",
+      account: address,
+      peer: this.iouIssuer,
+    } as any);
+
+    const lines = (resp.result as any).lines as {
+      currency: string;
+      account: string;
+    }[];
+    const hasLine = lines.some(
+      (l) =>
+        l.currency === this.iouCurrencyCode && l.account === this.iouIssuer,
+    );
+    if (hasLine) return;
+
+    const seed = this.decrypt(encryptedSeed);
+    const wallet = Wallet.fromSeed(seed);
+    const tx = {
+      TransactionType: "TrustSet" as const,
+      Account: address,
+      LimitAmount: {
+        currency: this.iouCurrencyCode,
+        issuer: this.iouIssuer,
+        value: "1000000000",
+      },
+    };
+    const prepared = await this.client.autofill(tx);
+    const { tx_blob } = wallet.sign(prepared);
+    const result = await this.client.submitAndWait(tx_blob);
+
+    const meta = result.result.meta as any;
+    if (meta?.TransactionResult !== "tesSUCCESS") {
+      throw new XrplTransactionFailedException(
+        "TrustSet",
+        meta?.TransactionResult ?? "unknown",
+      );
+    }
+
+    this.logger.log(
+      `IOU trust line created for ${address} (${this.iouCurrencyCode})`,
+    );
+  }
+
+  /**
+   * buyer의 IOU 잔고 검증
+   * trust line의 balance가 총 에스크로 금액 이상인지 확인
+   */
+  async validateRlusdFunds(
+    buyerAddress: string,
+    escrows: { amountXrp: number }[],
+  ): Promise<void> {
+    await this.connect();
+
+    const resp = await this.client.request({
+      command: "account_lines",
+      account: buyerAddress,
+      peer: this.iouIssuer,
+    } as any);
+
+    const lines = (resp.result as any).lines as {
+      currency: string;
+      account: string;
+      balance: string;
+    }[];
+    const line = lines.find(
+      (l) =>
+        l.currency === this.iouCurrencyCode && l.account === this.iouIssuer,
+    );
+
+    const balance = parseFloat(line?.balance ?? "0");
+    const required = escrows.reduce((sum, e) => sum + e.amountXrp, 0);
+
+    if (balance < required) {
+      throw new InsufficientXrpBalanceException(balance, required);
+    }
+
+    this.logger.log(
+      `IOU balance check OK: ${balance} available, ${required} required (${this.iouCurrencyCode})`,
+    );
+  }
+
+  /**
+   * IOU 결제 전송 — 테스트 issuer가 buyer에게 토큰을 충전할 때 사용
+   */
+  async sendIssuedCurrencyPayment(
+    senderWallet: XrplWallet,
+    destAddress: string,
+    amount: string,
+  ): Promise<string> {
+    await this.connect();
+    const wallet = Wallet.fromSeed(senderWallet.seed);
+
+    const tx = {
+      TransactionType: "Payment" as const,
+      Account: senderWallet.address,
+      Destination: destAddress,
+      Amount: {
+        currency: this.iouCurrencyCode,
+        issuer: this.iouIssuer,
+        value: amount,
+      },
+    };
+    const prepared = await this.client.autofill(tx);
+    const { tx_blob } = wallet.sign(prepared);
+    const result = await this.client.submitAndWait(tx_blob);
+
+    const meta = result.result.meta as any;
+    if (meta?.TransactionResult !== "tesSUCCESS") {
+      throw new XrplTransactionFailedException(
+        "Payment",
+        meta?.TransactionResult ?? "unknown",
+      );
+    }
+
+    return result.result.hash;
+  }
+
+  private buildEscrowAmount(
+    currency: "XRP" | "RLUSD",
+    amount: number,
+  ): string | { value: string; currency: string; issuer: string } {
+    if (currency === "XRP") {
+      return xrpToDrops(amount);
+    }
+    return {
+      value: amount.toFixed(6),
+      currency: this.iouCurrencyCode,
+      issuer: this.iouIssuer,
+    };
   }
 }

--- a/src/modules/xrpl/xrpl.service.ts
+++ b/src/modules/xrpl/xrpl.service.ts
@@ -18,6 +18,7 @@ import {
 import * as crypto from "crypto";
 import {
   InsufficientXrpBalanceException,
+  InsufficientRlusdBalanceException,
   InvalidCipherTextException,
   XrplConnectionException,
   XrplTransactionFailedException,
@@ -600,11 +601,13 @@ export class XrplService implements OnModuleInit, OnModuleDestroy {
         l.currency === this.iouCurrencyCode && l.account === this.iouIssuer,
     );
 
-    const balance = parseFloat(line?.balance ?? "0");
-    const required = escrows.reduce((sum, e) => sum + e.amountXrp, 0);
+    const balance = parseFloat(parseFloat(line?.balance ?? "0").toFixed(6));
+    const required = parseFloat(
+      escrows.reduce((sum, e) => sum + e.amountXrp, 0).toFixed(6),
+    );
 
     if (balance < required) {
-      throw new InsufficientXrpBalanceException(balance, required);
+      throw new InsufficientRlusdBalanceException(balance, required);
     }
 
     this.logger.log(
@@ -656,7 +659,7 @@ export class XrplService implements OnModuleInit, OnModuleDestroy {
       return xrpToDrops(amount);
     }
     return {
-      value: amount.toFixed(6),
+      value: new BigNumber(amount).toFixed(),
       currency: this.iouCurrencyCode,
       issuer: this.iouIssuer,
     };

--- a/test/escrow-mock.e2e-spec.ts
+++ b/test/escrow-mock.e2e-spec.ts
@@ -20,7 +20,7 @@ import { MongoMemoryReplSet } from "mongodb-memory-server";
 import { Model, Types } from "mongoose";
 import session from "express-session";
 import { EscrowPaymentsModule } from "../src/modules/escrow-payments/escrow-payments.module";
-import { EscrowPaymentsService } from "../src/modules/escrow-payments/escrow-payments.service";
+import { EscrowCreateProcessor } from "../src/modules/escrow-payments/escrow-create.processor";
 import { ESCROW_CREATE_QUEUE } from "../src/modules/escrow-payments/escrow-create.constants";
 import { XrplService } from "../src/modules/xrpl/xrpl.service";
 import { OutboxService } from "../src/modules/outbox/outbox.service";
@@ -97,7 +97,7 @@ describe("EscrowPayments (e2e)", () => {
       .compile();
 
     // compile() 후 서비스 참조를 얻어 mock 구현 완성
-    const escrowService = moduleFixture.get(EscrowPaymentsService);
+    const processor = moduleFixture.get(EscrowCreateProcessor);
 
     // 큐 add → 에스크로 항목별로 createXrplEscrow 인라인 실행
     mockQueue.add.mockImplementation(
@@ -109,7 +109,7 @@ describe("EscrowPayments (e2e)", () => {
         escrowIds: string[];
       }) => {
         for (const id of escrowIds) {
-          await escrowService.createXrplEscrow(paymentId, id);
+          await processor.createXrplEscrow(paymentId, id);
         }
       },
     );
@@ -669,6 +669,7 @@ describe("EscrowPayments (e2e)", () => {
         "rSellerE2ETestAddr5678",
         300,
         "A02580204ABCDEF",
+        "XRP",
       );
     });
 

--- a/test/escrow-rlusd-mock.e2e-spec.ts
+++ b/test/escrow-rlusd-mock.e2e-spec.ts
@@ -1,0 +1,467 @@
+/**
+ * RLUSD 에스크로 결제 mock e2e 테스트
+ *
+ * XRP 플로우와 동일한 인프라 위에서 RLUSD 고유 동작만 검증:
+ *   - initiatePayment 시 ensureRlusdTrustLine(buyer), ensureRlusdTrustLine(seller) 양측 호출
+ *   - validateRlusdFunds 호출 (validateEscrowFunds 미호출)
+ *   - createEscrow 호출 시 currency: 'RLUSD' 전달
+ *   - RLUSD 잔고 부족 시 400 반환
+ *   - 이벤트 양방향 승인 → EscrowFinish → COMPLETED 전체 플로우
+ *
+ * 실행: npm run test:e2e -- --testPathPatterns=escrow-rlusd-mock
+ */
+
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication, ValidationPipe } from "@nestjs/common";
+import request from "supertest";
+import { MongooseModule, getModelToken } from "@nestjs/mongoose";
+import { BullModule, getQueueToken } from "@nestjs/bull";
+import { MongoMemoryReplSet } from "mongodb-memory-server";
+import { Model, Types } from "mongoose";
+import session from "express-session";
+import { EscrowPaymentsModule } from "../src/modules/escrow-payments/escrow-payments.module";
+import { EscrowCreateProcessor } from "../src/modules/escrow-payments/escrow-create.processor";
+import { ESCROW_CREATE_QUEUE } from "../src/modules/escrow-payments/escrow-create.constants";
+import { XrplService } from "../src/modules/xrpl/xrpl.service";
+import { OutboxService } from "../src/modules/outbox/outbox.service";
+import { OutboxWatcherService } from "../src/modules/outbox/outbox-watcher.service";
+import { User } from "../src/modules/users/schemas/user.schema";
+import { HttpExceptionFilter } from "../src/common/filters/http-exception.filter";
+import { InsufficientXrpBalanceException } from "../src/common/exceptions";
+
+const BUYER_ADDRESS = "rBuyerRlusdTestAddr";
+const SELLER_ADDRESS = "rSellerRlusdTestAddr";
+
+describe("RLUSD 에스크로 결제 (mock e2e)", () => {
+  let app: INestApplication;
+  let mongoServer: MongoMemoryReplSet;
+  let userModel: Model<User>;
+
+  const buyerObjectId = new Types.ObjectId();
+  const sellerObjectId = new Types.ObjectId();
+
+  const mockXrplService = {
+    generateCryptoCondition: jest.fn(),
+    encrypt: jest.fn(),
+    decrypt: jest.fn(),
+    createEscrow: jest.fn(),
+    finishEscrow: jest.fn(),
+    cancelEscrow: jest.fn(),
+    validateEscrowFunds: jest.fn(),
+    ensureRlusdTrustLine: jest.fn(),
+    validateRlusdFunds: jest.fn(),
+  };
+
+  const mockOutboxService = { createPendingEvent: jest.fn() };
+  const mockOutboxWatcherService = {
+    onApplicationBootstrap: jest.fn().mockResolvedValue(undefined),
+    onApplicationShutdown: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
+    const mongoUri = mongoServer.getUri();
+
+    const mockQueue = {
+      add: jest.fn(),
+      process: jest.fn(),
+      on: jest.fn(),
+      pause: jest.fn(),
+      resume: jest.fn(),
+      close: jest.fn(),
+      isReady: jest.fn().mockResolvedValue(true),
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        BullModule.forRoot({ redis: { host: "localhost", port: 6379 } }),
+        MongooseModule.forRoot(mongoUri),
+        EscrowPaymentsModule,
+      ],
+    })
+      .overrideProvider(XrplService)
+      .useValue(mockXrplService)
+      .overrideProvider(getQueueToken(ESCROW_CREATE_QUEUE))
+      .useValue(mockQueue)
+      .overrideProvider(OutboxService)
+      .useValue(mockOutboxService)
+      .overrideProvider(OutboxWatcherService)
+      .useValue(mockOutboxWatcherService)
+      .compile();
+
+    const processor = moduleFixture.get(EscrowCreateProcessor);
+
+    mockQueue.add.mockImplementation(
+      async ({
+        paymentId,
+        escrowIds,
+      }: {
+        paymentId: string;
+        escrowIds: string[];
+      }) => {
+        for (const id of escrowIds) {
+          await processor.createXrplEscrow(paymentId, id);
+        }
+      },
+    );
+
+    mockOutboxService.createPendingEvent.mockImplementation(
+      (_session: any, _eventType: string, payload: any) => {
+        setTimeout(() => void mockQueue.add(payload), 50);
+      },
+    );
+
+    app = moduleFixture.createNestApplication();
+    app.use(
+      session({
+        secret: "ci-test-secret",
+        resave: false,
+        saveUninitialized: true,
+        cookie: { secure: false },
+      }),
+    );
+    app.use((req: any, _res: any, next: any) => {
+      const userId = req.headers["x-test-user-id"] as string | undefined;
+      const userType = req.headers["x-test-user-type"] as string | undefined;
+      if (userId && userType) {
+        req.session.userId = userId;
+        req.session.type = userType;
+      }
+      next();
+    });
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+
+    userModel = moduleFixture.get<Model<User>>(getModelToken(User.name));
+
+    await (userModel as any).collection.insertMany([
+      {
+        _id: buyerObjectId,
+        email: "buyer@rlusd-e2e.com",
+        password: "hashed",
+        name: "RLUSD Buyer Corp",
+        contactName: "Buyer",
+        phone: "010-0000-0001",
+        type: "buyer",
+        needs: [],
+        industries: [],
+        status: "ACTIVE",
+        wallet: {
+          address: BUYER_ADDRESS,
+          seed: "enc:buyer_seed",
+          publicKey: "buyer_pub",
+        },
+      },
+      {
+        _id: sellerObjectId,
+        email: "seller@rlusd-e2e.com",
+        password: "hashed",
+        name: "RLUSD Seller Corp",
+        contactName: "Seller",
+        phone: "010-0000-0002",
+        type: "seller",
+        exportItems: [],
+        industries: [],
+        status: "ACTIVE",
+        wallet: {
+          address: SELLER_ADDRESS,
+          seed: "enc:seller_seed",
+          publicKey: "seller_pub",
+        },
+      },
+    ]);
+  }, 60_000);
+
+  afterAll(async () => {
+    await app.close();
+    await mongoServer.stop();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockXrplService.generateCryptoCondition.mockReturnValue({
+      condition: "A02580204ABCDEF",
+      fulfillment: "A022802012345678",
+    });
+    mockXrplService.encrypt.mockImplementation((v: string) => `enc:${v}`);
+    mockXrplService.decrypt.mockImplementation((v: string) =>
+      v.replace(/^enc:/, ""),
+    );
+    mockXrplService.ensureRlusdTrustLine.mockResolvedValue(undefined);
+    mockXrplService.validateRlusdFunds.mockResolvedValue(undefined);
+    mockXrplService.createEscrow.mockResolvedValue({
+      txHash: "RLUSD_CREATE_TX_HASH",
+      sequence: 12345,
+    });
+    mockXrplService.finishEscrow.mockResolvedValue("RLUSD_FINISH_TX_HASH");
+  });
+
+  const asBuyer = () => ({
+    "x-test-user-id": buyerObjectId.toString(),
+    "x-test-user-type": "buyer",
+  });
+  const asSeller = () => ({
+    "x-test-user-id": sellerObjectId.toString(),
+    "x-test-user-type": "seller",
+  });
+
+  async function waitForEscrowStatus(
+    paymentId: string,
+    escrowId: string,
+    expected: string,
+    timeoutMs = 5_000,
+  ) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const res = await request(app.getHttpServer())
+        .get(`/escrow-payments/${paymentId}/escrows/${escrowId}/status`)
+        .set(asBuyer());
+      if (res.body.status === expected) return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    throw new Error(
+      `Escrow ${escrowId} did not reach '${expected}' within ${timeoutMs}ms`,
+    );
+  }
+
+  const rlusdCreatePayload = (overrides: object = {}) => ({
+    buyerId: buyerObjectId.toString(),
+    sellerId: sellerObjectId.toString(),
+    memo: "RLUSD 테스트 결제",
+    currency: "RLUSD",
+    escrows: [
+      {
+        label: "초기금",
+        amountXrp: 1000,
+        order: 0,
+        requiredEventTypes: ["SHIPMENT_CONFIRMED", "INSPECTION_PASSED"],
+      },
+    ],
+    ...overrides,
+  });
+
+  /** 결제 생성 → 양측 승인 → 개시 → ESCROWED 까지 진행하는 헬퍼 */
+  async function createRlusdEscrowedPayment() {
+    const createRes = await request(app.getHttpServer())
+      .post("/escrow-payments")
+      .set(asBuyer())
+      .send(rlusdCreatePayload())
+      .expect(201);
+
+    const paymentId: string = createRes.body._id;
+    const escrowItemId: string = createRes.body.escrows[0]._id;
+
+    await request(app.getHttpServer())
+      .post(`/escrow-payments/${paymentId}/approve`)
+      .set(asBuyer());
+    await request(app.getHttpServer())
+      .post(`/escrow-payments/${paymentId}/approve`)
+      .set(asSeller());
+    await request(app.getHttpServer())
+      .post(`/escrow-payments/${paymentId}/pay`)
+      .set(asBuyer())
+      .expect(201);
+
+    await waitForEscrowStatus(paymentId, escrowItemId, "ESCROWED");
+    return { paymentId, escrowItemId };
+  }
+
+  // ── 결제 생성 ────────────────────────────────────────────────────────────────
+
+  describe("POST /escrow-payments (RLUSD)", () => {
+    it("currency: RLUSD → 201, currency 필드 RLUSD로 저장", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/escrow-payments")
+        .set(asBuyer())
+        .send(rlusdCreatePayload())
+        .expect(201);
+
+      expect(res.body.currency).toBe("RLUSD");
+      expect(res.body.status).toBe("DRAFT");
+    });
+
+    it("currency 미전달 → XRP 기본값", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/escrow-payments")
+        .set(asBuyer())
+        .send({
+          buyerId: buyerObjectId.toString(),
+          sellerId: sellerObjectId.toString(),
+          escrows: [
+            {
+              label: "초기금",
+              amountXrp: 100,
+              order: 0,
+              requiredEventTypes: [],
+            },
+          ],
+        })
+        .expect(201);
+
+      expect(res.body.currency).toBe("XRP");
+    });
+
+    it("currency 잘못된 값 → 400", async () => {
+      await request(app.getHttpServer())
+        .post("/escrow-payments")
+        .set(asBuyer())
+        .send(rlusdCreatePayload({ currency: "BTC" }))
+        .expect(400);
+    });
+  });
+
+  // ── 결제 개시 pre-flight ──────────────────────────────────────────────────────
+
+  describe("POST /pay — RLUSD pre-flight", () => {
+    it("initiatePayment 시 buyer/seller 양측에 ensureRlusdTrustLine 호출", async () => {
+      const createRes = await request(app.getHttpServer())
+        .post("/escrow-payments")
+        .set(asBuyer())
+        .send(rlusdCreatePayload())
+        .expect(201);
+      const paymentId = createRes.body._id;
+
+      await request(app.getHttpServer())
+        .post(`/escrow-payments/${paymentId}/approve`)
+        .set(asBuyer());
+      await request(app.getHttpServer())
+        .post(`/escrow-payments/${paymentId}/approve`)
+        .set(asSeller());
+      await request(app.getHttpServer())
+        .post(`/escrow-payments/${paymentId}/pay`)
+        .set(asBuyer())
+        .expect(201);
+
+      expect(mockXrplService.ensureRlusdTrustLine).toHaveBeenCalledWith(
+        BUYER_ADDRESS,
+        "enc:buyer_seed",
+      );
+      expect(mockXrplService.ensureRlusdTrustLine).toHaveBeenCalledWith(
+        SELLER_ADDRESS,
+        "enc:seller_seed",
+      );
+      expect(mockXrplService.ensureRlusdTrustLine).toHaveBeenCalledTimes(2);
+    });
+
+    it("validateRlusdFunds 호출, validateEscrowFunds 미호출", async () => {
+      const createRes = await request(app.getHttpServer())
+        .post("/escrow-payments")
+        .set(asBuyer())
+        .send(rlusdCreatePayload())
+        .expect(201);
+      const paymentId = createRes.body._id;
+
+      await request(app.getHttpServer())
+        .post(`/escrow-payments/${paymentId}/approve`)
+        .set(asBuyer());
+      await request(app.getHttpServer())
+        .post(`/escrow-payments/${paymentId}/approve`)
+        .set(asSeller());
+      await request(app.getHttpServer())
+        .post(`/escrow-payments/${paymentId}/pay`)
+        .set(asBuyer())
+        .expect(201);
+
+      expect(mockXrplService.validateRlusdFunds).toHaveBeenCalledTimes(1);
+      expect(mockXrplService.validateEscrowFunds).not.toHaveBeenCalled();
+    });
+
+    it("RLUSD 잔고 부족 → 400", async () => {
+      mockXrplService.validateRlusdFunds.mockRejectedValue(
+        new InsufficientXrpBalanceException(200, 1000),
+      );
+
+      const createRes = await request(app.getHttpServer())
+        .post("/escrow-payments")
+        .set(asBuyer())
+        .send(rlusdCreatePayload())
+        .expect(201);
+      const paymentId = createRes.body._id;
+
+      await request(app.getHttpServer())
+        .post(`/escrow-payments/${paymentId}/approve`)
+        .set(asBuyer());
+      await request(app.getHttpServer())
+        .post(`/escrow-payments/${paymentId}/approve`)
+        .set(asSeller());
+
+      await request(app.getHttpServer())
+        .post(`/escrow-payments/${paymentId}/pay`)
+        .set(asBuyer())
+        .expect(400);
+    });
+  });
+
+  // ── EscrowCreate currency 전달 ────────────────────────────────────────────────
+
+  describe("createXrplEscrow — RLUSD currency 전달", () => {
+    it("createEscrow 호출 시 5번째 인자로 'RLUSD' 전달", async () => {
+      const { paymentId, escrowItemId } = await createRlusdEscrowedPayment();
+
+      // ESCROWED 상태 확인
+      const statusRes = await request(app.getHttpServer())
+        .get(`/escrow-payments/${paymentId}/escrows/${escrowItemId}/status`)
+        .set(asBuyer());
+      expect(statusRes.body.status).toBe("ESCROWED");
+
+      expect(mockXrplService.createEscrow).toHaveBeenCalledWith(
+        expect.anything(), // buyerWallet
+        SELLER_ADDRESS, // sellerAddress
+        1000, // amount
+        "A02580204ABCDEF", // condition
+        "RLUSD", // currency
+      );
+    });
+  });
+
+  // ── 전체 플로우 ───────────────────────────────────────────────────────────────
+
+  describe("RLUSD 전체 플로우: 생성 → 승인 → 개시 → 이벤트 완료 → COMPLETED", () => {
+    it("이벤트 2개 양방향 승인 완료 → RELEASED / COMPLETED", async () => {
+      const { paymentId, escrowItemId } = await createRlusdEscrowedPayment();
+
+      // 이벤트1 buyer 승인
+      await request(app.getHttpServer())
+        .post(
+          `/escrow-payments/${paymentId}/escrows/${escrowItemId}/events/SHIPMENT_CONFIRMED/approve`,
+        )
+        .set(asBuyer())
+        .expect(201);
+
+      // 이벤트1 seller 승인
+      await request(app.getHttpServer())
+        .post(
+          `/escrow-payments/${paymentId}/escrows/${escrowItemId}/events/SHIPMENT_CONFIRMED/approve`,
+        )
+        .set(asSeller())
+        .expect(201);
+
+      // 이벤트2 buyer 승인
+      await request(app.getHttpServer())
+        .post(
+          `/escrow-payments/${paymentId}/escrows/${escrowItemId}/events/INSPECTION_PASSED/approve`,
+        )
+        .set(asBuyer())
+        .expect(201);
+
+      // 이벤트2 seller 승인 → 전체 완료 → EscrowFinish
+      const finalRes = await request(app.getHttpServer())
+        .post(
+          `/escrow-payments/${paymentId}/escrows/${escrowItemId}/events/INSPECTION_PASSED/approve`,
+        )
+        .set(asSeller())
+        .expect(201);
+
+      const finalEscrow = finalRes.body.escrows.find(
+        (e: any) => e._id === escrowItemId,
+      );
+
+      expect(finalEscrow.status).toBe("RELEASED");
+      expect(finalEscrow.txHashRelease).toBe("RLUSD_FINISH_TX_HASH");
+      expect(finalRes.body.status).toBe("COMPLETED");
+    });
+  });
+});

--- a/test/escrow-rlusd-mock.e2e-spec.ts
+++ b/test/escrow-rlusd-mock.e2e-spec.ts
@@ -27,7 +27,7 @@ import { OutboxService } from "../src/modules/outbox/outbox.service";
 import { OutboxWatcherService } from "../src/modules/outbox/outbox-watcher.service";
 import { User } from "../src/modules/users/schemas/user.schema";
 import { HttpExceptionFilter } from "../src/common/filters/http-exception.filter";
-import { InsufficientXrpBalanceException } from "../src/common/exceptions";
+import { InsufficientRlusdBalanceException } from "../src/common/exceptions";
 
 const BUYER_ADDRESS = "rBuyerRlusdTestAddr";
 const SELLER_ADDRESS = "rSellerRlusdTestAddr";
@@ -371,7 +371,7 @@ describe("RLUSD 에스크로 결제 (mock e2e)", () => {
 
     it("RLUSD 잔고 부족 → 400", async () => {
       mockXrplService.validateRlusdFunds.mockRejectedValue(
-        new InsufficientXrpBalanceException(200, 1000),
+        new InsufficientRlusdBalanceException(200, 1000),
       );
 
       const createRes = await request(app.getHttpServer())

--- a/test/escrow-rlusd-testnet.e2e-spec.ts
+++ b/test/escrow-rlusd-testnet.e2e-spec.ts
@@ -1,0 +1,377 @@
+/**
+ * RLUSD 에스크로 결제 테스트넷 통합 테스트
+ *
+ * 실제 XRPL testnet + MongoMemoryReplSet + 실제 Redis(Bull Queue) + OutboxWatcherService(Change Streams)
+ * 로 RLUSD 토큰 에스크로 결제 플로우를 검증합니다.
+ *
+ * RLUSD faucet이 없으므로 테스트 전용 issuer 지갑을 직접 생성합니다:
+ *   issuer 지갑 → buyer/seller에게 trust line 설정 → issuer가 buyer에게 토큰 전송
+ *
+ * 플로우:
+ *   1. 결제 생성 (currency: RLUSD)
+ *   2. 양측 승인 → APPROVED
+ *   3. 결제 개시 → trust line 자동 확인 + 잔고 검증 → PROCESSING + Outbox
+ *   4. OutboxWatcher → EscrowCreateProcessor → XLS-85 EscrowCreate → ESCROWED → ACTIVE
+ *   5. 이벤트 2개 양방향 승인 → EscrowFinish → RELEASED / COMPLETED
+ *
+ * 사전 조건:
+ *   - Redis 로컬 실행 중 (localhost:6379)
+ *   - XRPL testnet 접근 가능 (wss://s.altnet.rippletest.net:51233)
+ *   - XLS-85(Token-Enabled Escrows) 활성화 필요
+ *     미활성 시 EscrowCreate 단계에서 실패 (이전 단계인 trust line / 잔고 검증은 동작)
+ *
+ * 실행: npm run test:e2e:rlusd-testnet
+ */
+
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { MongooseModule, getModelToken } from "@nestjs/mongoose";
+import { BullModule } from "@nestjs/bull";
+import { MongoMemoryReplSet } from "mongodb-memory-server";
+import { Model, Types } from "mongoose";
+import { Wallet } from "xrpl";
+import { EscrowPaymentsModule } from "../src/modules/escrow-payments/escrow-payments.module";
+import { EscrowPaymentsService } from "../src/modules/escrow-payments/escrow-payments.service";
+import { EscrowPaymentsCrudService } from "../src/modules/escrow-payments/escrow-payments-crud.service";
+import { XrplService } from "../src/modules/xrpl/xrpl.service";
+import { User } from "../src/modules/users/schemas/user.schema";
+
+const TEST_ENCRYPTION_KEY = "a".repeat(64);
+const TESTNET_WS = "wss://s.altnet.rippletest.net:51233";
+// 테스트 전용 IOU currency code (3자리: XRPL 표준 형식)
+const TEST_CURRENCY_CODE = "TST";
+
+// ── issuer 지갑을 모듈 초기화 전에 생성 ───────────────────────────────────────
+// Wallet.generate()는 동기 실행 → 생성된 주소를 ConfigModule에 바로 주입 가능
+const issuerXrplWallet = Wallet.generate();
+
+// ── 폴링 헬퍼 ─────────────────────────────────────────────────────────────────
+
+async function waitForEscrowStatus(
+  service: EscrowPaymentsService,
+  paymentId: string,
+  escrowId: string,
+  expected: string,
+  timeoutMs = 60_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = "(unknown)";
+  while (Date.now() < deadline) {
+    const item = await service.getEscrowStatus(paymentId, escrowId);
+    lastStatus = item.status;
+    if (item.status === expected) return item;
+    // 비재시도 오류로 CANCELLED된 경우 즉시 실패 (더 기다려도 무의미)
+    if (item.status === "CANCELLED") {
+      throw new Error(
+        `Escrow ${escrowId} was CANCELLED (XLS-85 미활성 또는 영구 오류). ` +
+          `temDISABLED = XLS-85 amendment not active on testnet.`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 1_000));
+  }
+  throw new Error(
+    `Escrow ${escrowId} did not reach '${expected}' within ${timeoutMs}ms. ` +
+      `Last status: ${lastStatus}`,
+  );
+}
+
+async function waitForPaymentStatus(
+  service: EscrowPaymentsCrudService,
+  paymentId: string,
+  userId: string,
+  expected: string,
+  timeoutMs = 60_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const payment = await service.findById(paymentId, userId);
+    if (payment.status === expected) return payment;
+    await new Promise((r) => setTimeout(r, 1_000));
+  }
+  throw new Error(
+    `Payment ${paymentId} did not reach '${expected}' within ${timeoutMs}ms`,
+  );
+}
+
+// ── 테스트 ─────────────────────────────────────────────────────────────────────
+
+describe("RLUSD 에스크로 결제 테스트넷 통합 테스트", () => {
+  let module: TestingModule;
+  let mongoServer: MongoMemoryReplSet;
+  let xrplService: XrplService;
+  let escrowPaymentsService: EscrowPaymentsService;
+  let crudService: EscrowPaymentsCrudService;
+  let userModel: Model<User>;
+
+  const buyerObjectId = new Types.ObjectId();
+  const sellerObjectId = new Types.ObjectId();
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
+    const mongoUri = mongoServer.getUri();
+
+    module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [
+            () => ({
+              xrpl: {
+                wsUrl: TESTNET_WS,
+                destAddress: "",
+                // 모듈 초기화 전에 생성한 issuer 지갑 주소 주입
+                issuerAddress: issuerXrplWallet.address,
+                issuedCurrencyCode: TEST_CURRENCY_CODE,
+              },
+              security: { encryptionKey: TEST_ENCRYPTION_KEY },
+              REDIS_HOST: process.env.REDIS_HOST || "localhost",
+              REDIS_PORT: Number(process.env.REDIS_PORT) || 6379,
+            }),
+          ],
+        }),
+        BullModule.forRoot({
+          redis: {
+            host: process.env.REDIS_HOST || "localhost",
+            port: Number(process.env.REDIS_PORT) || 6379,
+            password: process.env.REDIS_PASSWORD || undefined,
+          },
+        }),
+        MongooseModule.forRoot(mongoUri),
+        EscrowPaymentsModule,
+      ],
+    }).compile();
+
+    await module.init();
+
+    xrplService = module.get<XrplService>(XrplService);
+    escrowPaymentsService = module.get<EscrowPaymentsService>(
+      EscrowPaymentsService,
+    );
+    crudService = module.get<EscrowPaymentsCrudService>(
+      EscrowPaymentsCrudService,
+    );
+    userModel = module.get<Model<User>>(getModelToken(User.name));
+
+    // ── 지갑 생성 및 XRP faucet 펀딩 ────────────────────────────────────────
+    // issuer: TrustSet/Payment 수수료용 XRP 필요
+    // buyer: Trust Line reserve(2 XRP) + 수수료 필요
+    // seller: Trust Line reserve(2 XRP) + 수수료 필요
+    const buyerWallet = xrplService.generateWallet();
+    const sellerWallet = xrplService.generateWallet();
+
+    const issuerWallet = {
+      address: issuerXrplWallet.address,
+      seed: issuerXrplWallet.seed!,
+      publicKey: issuerXrplWallet.publicKey,
+      privateKey: issuerXrplWallet.privateKey,
+    };
+
+    await Promise.all([
+      xrplService.fundAccount(issuerWallet),
+      xrplService.fundAccount(buyerWallet),
+      xrplService.fundAccount(sellerWallet),
+    ]);
+
+    // issuer 계정에 AllowTrustLineLocking 설정 (asfAllowTrustLineLocking = 17)
+    // XLS-85: issuer가 이 플래그 없으면 EscrowCreate 시 tecNO_PERMISSION
+    await xrplService.enableTrustLineLocking(issuerWallet);
+
+    // ── trust line 설정: buyer/seller → issuer ───────────────────────────────
+    // initiatePayment에서도 ensureRlusdTrustLine을 호출하지만,
+    // 그 전에 buyer에게 토큰을 전송해야 하므로 여기서 미리 설정
+    const encryptedBuyerSeed = xrplService.encrypt(buyerWallet.seed);
+    const encryptedSellerSeed = xrplService.encrypt(sellerWallet.seed);
+
+    await Promise.all([
+      xrplService.ensureRlusdTrustLine(buyerWallet.address, encryptedBuyerSeed),
+      xrplService.ensureRlusdTrustLine(
+        sellerWallet.address,
+        encryptedSellerSeed,
+      ),
+    ]);
+
+    // ── issuer → buyer 토큰 전송 (에스크로 금액 이상) ────────────────────────
+    await xrplService.sendIssuedCurrencyPayment(
+      issuerWallet,
+      buyerWallet.address,
+      "10000", // 10,000 TST — 테스트 에스크로(10 TST) 충분히 커버
+    );
+
+    // ── MongoDB에 buyer / seller 저장 ────────────────────────────────────────
+    await (userModel as any).collection.insertMany([
+      {
+        _id: buyerObjectId,
+        email: "buyer@rlusd-testnet.com",
+        password: "hashed",
+        name: "RLUSD Testnet Buyer",
+        contactName: "Buyer",
+        phone: "010-0000-0001",
+        type: "buyer",
+        needs: [],
+        industries: [],
+        status: "ACTIVE",
+        wallet: {
+          address: buyerWallet.address,
+          seed: encryptedBuyerSeed,
+          publicKey: buyerWallet.publicKey,
+        },
+      },
+      {
+        _id: sellerObjectId,
+        email: "seller@rlusd-testnet.com",
+        password: "hashed",
+        name: "RLUSD Testnet Seller",
+        contactName: "Seller",
+        phone: "010-0000-0002",
+        type: "seller",
+        exportItems: [],
+        industries: [],
+        status: "ACTIVE",
+        wallet: {
+          address: sellerWallet.address,
+          seed: encryptedSellerSeed,
+          publicKey: sellerWallet.publicKey,
+        },
+      },
+    ]);
+  }, 180_000); // faucet 펀딩 × 3 + trust line × 2 + token send
+
+  afterAll(async () => {
+    await module.close();
+    await mongoServer.stop();
+  });
+
+  it("TST 토큰 에스크로: 생성 → 이벤트 2개 양방향 승인 → EscrowFinish", async () => {
+    // ── 1. 결제 생성 ─────────────────────────────────────────────────────
+    const payment = await crudService.create(
+      {
+        buyerId: buyerObjectId.toString(),
+        sellerId: sellerObjectId.toString(),
+        memo: "테스트넷 TST 토큰 에스크로",
+        currency: "RLUSD", // 서비스 분기 기준: RLUSD 코드 경로 사용
+        escrows: [
+          {
+            label: "초기금",
+            amountXrp: 10, // TST 단위 (amountXrp 필드를 amount로 재사용)
+            order: 0,
+            requiredEventTypes: ["SHIPMENT_CONFIRMED", "INSPECTION_PASSED"],
+          },
+        ],
+      },
+      buyerObjectId.toString(),
+    );
+
+    const paymentId = payment._id.toString();
+    const escrowItemId = payment.escrows[0]._id.toString();
+
+    expect(payment.status).toBe("DRAFT");
+    expect(payment.currency).toBe("RLUSD");
+
+    // ── 2. 양측 승인 → APPROVED ──────────────────────────────────────────
+    await escrowPaymentsService.approvePayment(
+      paymentId,
+      buyerObjectId.toString(),
+    );
+    const afterApprove = await escrowPaymentsService.approvePayment(
+      paymentId,
+      sellerObjectId.toString(),
+    );
+
+    expect(afterApprove.status).toBe("APPROVED");
+
+    // ── 3. 결제 개시 → PROCESSING ────────────────────────────────────────
+    // initiatePayment:
+    //   ensureRlusdTrustLine(buyer) → 이미 설정됨, skip
+    //   ensureRlusdTrustLine(seller) → 이미 설정됨, skip
+    //   validateRlusdFunds → buyer 잔고 10,000 TST ≥ 10 TST → 통과
+    const afterInitiate = await escrowPaymentsService.initiatePayment(
+      paymentId,
+      buyerObjectId.toString(),
+    );
+
+    expect(afterInitiate.status).toBe("PROCESSING");
+
+    // ── 4. 비동기 XLS-85 EscrowCreate 완료 대기 ─────────────────────────
+    // OutboxWatcher → escrow_create_queue → EscrowCreateProcessor
+    //   → xrplService.createEscrow(..., 'RLUSD')
+    //   → Amount: { currency: 'TST', issuer: issuerAddress, value: '10' }
+    //
+    // ⚠️  XLS-85가 testnet에서 미활성화 상태이면 이 단계에서 실패합니다.
+    //    (trust line 설정 및 잔고 검증은 정상 동작)
+    const escrowItem = await waitForEscrowStatus(
+      escrowPaymentsService,
+      paymentId,
+      escrowItemId,
+      "ESCROWED",
+      60_000,
+    );
+    const activePayment = await waitForPaymentStatus(
+      crudService,
+      paymentId,
+      buyerObjectId.toString(),
+      "ACTIVE",
+      30_000,
+    );
+
+    expect(escrowItem.status).toBe("ESCROWED");
+    expect(escrowItem.amountXrp).toBe(10);
+    expect(escrowItem.txHashCreate).toMatch(/^[A-F0-9]{64}$/);
+    expect(escrowItem.xrplSequence).toBeGreaterThan(0);
+    expect(activePayment.status).toBe("ACTIVE");
+
+    // ── 5. 이벤트1 buyer 승인 ────────────────────────────────────────────
+    const afterE1Buyer = await escrowPaymentsService.approveEvent(
+      paymentId,
+      escrowItemId,
+      "SHIPMENT_CONFIRMED",
+      buyerObjectId.toString(),
+    );
+    const e1b = afterE1Buyer.escrows.find(
+      (e) => e._id.toString() === escrowItemId,
+    )!;
+    expect(
+      e1b.approvals.find((a) => a.eventType === "SHIPMENT_CONFIRMED")!
+        .buyerApproved,
+    ).toBe(true);
+    expect(e1b.status).toBe("ESCROWED");
+
+    // ── 6. 이벤트1 seller 승인 ───────────────────────────────────────────
+    const afterE1Seller = await escrowPaymentsService.approveEvent(
+      paymentId,
+      escrowItemId,
+      "SHIPMENT_CONFIRMED",
+      sellerObjectId.toString(),
+    );
+    const e1s = afterE1Seller.escrows.find(
+      (e) => e._id.toString() === escrowItemId,
+    )!;
+    expect(
+      e1s.approvals.find((a) => a.eventType === "SHIPMENT_CONFIRMED")!
+        .completedAt,
+    ).toBeDefined();
+    expect(e1s.status).toBe("ESCROWED");
+
+    // ── 7. 이벤트2 buyer 승인 ────────────────────────────────────────────
+    await escrowPaymentsService.approveEvent(
+      paymentId,
+      escrowItemId,
+      "INSPECTION_PASSED",
+      buyerObjectId.toString(),
+    );
+
+    // ── 8. 이벤트2 seller 승인 → 전체 완료 → 자동 EscrowFinish ──────────
+    const finalPayment = await escrowPaymentsService.approveEvent(
+      paymentId,
+      escrowItemId,
+      "INSPECTION_PASSED",
+      sellerObjectId.toString(),
+    );
+    const finalEscrow = finalPayment.escrows.find(
+      (e) => e._id.toString() === escrowItemId,
+    )!;
+
+    expect(finalEscrow.status).toBe("RELEASED");
+    expect(finalEscrow.txHashRelease).toMatch(/^[A-F0-9]{64}$/);
+    expect(finalPayment.status).toBe("COMPLETED");
+  }, 300_000);
+});

--- a/test/escrow-testnet.e2e-spec.ts
+++ b/test/escrow-testnet.e2e-spec.ts
@@ -27,6 +27,7 @@ import { MongoMemoryReplSet } from "mongodb-memory-server";
 import { Model, Types } from "mongoose";
 import { EscrowPaymentsModule } from "../src/modules/escrow-payments/escrow-payments.module";
 import { EscrowPaymentsService } from "../src/modules/escrow-payments/escrow-payments.service";
+import { EscrowPaymentsCrudService } from "../src/modules/escrow-payments/escrow-payments-crud.service";
 import { XrplService } from "../src/modules/xrpl/xrpl.service";
 import { User } from "../src/modules/users/schemas/user.schema";
 
@@ -52,7 +53,7 @@ async function waitForEscrowStatus(
 }
 
 async function waitForPaymentStatus(
-  service: EscrowPaymentsService,
+  service: EscrowPaymentsCrudService,
   paymentId: string,
   userId: string,
   expected: string,
@@ -74,6 +75,7 @@ describe("XRPL Escrow Testnet (풀스택 통합 테스트)", () => {
   let mongoServer: MongoMemoryReplSet;
   let xrplService: XrplService;
   let escrowPaymentsService: EscrowPaymentsService;
+  let crudService: EscrowPaymentsCrudService;
   let userModel: Model<User>;
   let buyerWalletAddress: string;
 
@@ -91,7 +93,11 @@ describe("XRPL Escrow Testnet (풀스택 통합 테스트)", () => {
           isGlobal: true,
           load: [
             () => ({
-              xrpl: { wsUrl: TESTNET_WS, destAddress: "" },
+              xrpl: {
+                wsUrl: TESTNET_WS,
+                destAddress: "",
+                issuerAddress: "dummy",
+              },
               security: { encryptionKey: TEST_ENCRYPTION_KEY },
               REDIS_HOST: process.env.REDIS_HOST || "localhost",
               REDIS_PORT: Number(process.env.REDIS_PORT) || 6379,
@@ -117,6 +123,9 @@ describe("XRPL Escrow Testnet (풀스택 통합 테스트)", () => {
     xrplService = module.get<XrplService>(XrplService);
     escrowPaymentsService = module.get<EscrowPaymentsService>(
       EscrowPaymentsService,
+    );
+    crudService = module.get<EscrowPaymentsCrudService>(
+      EscrowPaymentsCrudService,
     );
     userModel = module.get<Model<User>>(getModelToken(User.name));
 
@@ -179,7 +188,7 @@ describe("XRPL Escrow Testnet (풀스택 통합 테스트)", () => {
 
   it("초기금 에스크로 생성 → 이벤트 2개 양방향 승인 완료 시 자동 EscrowFinish", async () => {
     // ── 1. 결제 내역 생성 ─────────────────────────────────────────────────
-    const payment = await escrowPaymentsService.create(
+    const payment = await crudService.create(
       {
         buyerId: buyerObjectId.toString(),
         sellerId: sellerObjectId.toString(),
@@ -253,7 +262,7 @@ describe("XRPL Escrow Testnet (풀스택 통합 테스트)", () => {
       60_000,
     );
     const activePayment = await waitForPaymentStatus(
-      escrowPaymentsService,
+      crudService,
       paymentId,
       buyerObjectId.toString(),
       "ACTIVE",

--- a/test/jest-e2e-rlusd-testnet.json
+++ b/test/jest-e2e-rlusd-testnet.json
@@ -1,0 +1,10 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "..",
+  "testEnvironment": "node",
+  "testRegex": "test/escrow-rlusd-testnet\\.e2e-spec\\.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "testTimeout": 300000
+}

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -3,7 +3,7 @@
   "rootDir": "..",
   "testEnvironment": "node",
   "testRegex": "test/.*\\.e2e-spec\\.ts$",
-  "testPathIgnorePatterns": ["test/xrpl-testnet\\.e2e-spec\\.ts", "test/escrow-testnet\\.e2e-spec\\.ts"],
+  "testPathIgnorePatterns": ["test/xrpl-testnet\\.e2e-spec\\.ts", "test/escrow-testnet\\.e2e-spec\\.ts", "test/escrow-rlusd-testnet\\.e2e-spec\\.ts"],
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },


### PR DESCRIPTION
Resolves #15 
## 개요

XRP 에스크로에 이어 **RLUSD(IOU 토큰) 에스크로 결제**를 지원합니다.
XLS-85(Token-Enabled Escrows) 어멘드먼트 기반으로 동작하며,
기존 XRP 플로우와 동일한 인터페이스(`currency: "RLUSD"` 필드 추가)로 사용됩니다.

서비스 계층도 함께 정리했습니다 — `EscrowPaymentsService`가 담당하던 CRUD,
XRPL 생성, 복구 로직을 각 책임 레이어로 분리했습니다.

---

## 주요 변경사항

### RLUSD 지원 (`XrplService`)
- `createEscrow` / `finishEscrow`에 `currency` 분기 추가 (XRP ↔ RLUSD Amount 형식 분리)
- `ensureRlusdTrustLine` — buyer/seller Trust Line 자동 설정
- `validateRlusdFunds` — 토큰 잔고 검증
- `enableTrustLineLocking` — issuer 계정 `asfAllowTrustLineLocking` 플래그 설정
- `sendIssuedCurrencyPayment` — issuer → 계정 토큰 전송 (테스트/초기화용)

### 서비스 레이어 리팩토링
| 이전 (`EscrowPaymentsService`) | 이후 |
|---|---|
| `create / findAll / findById` | → `EscrowPaymentsCrudService` |
| `createXrplEscrow` | → `EscrowCreateProcessor` (직접 실행) |
| `recoverSubmittingEscrow` / `cancelSubmittingEscrowAndRollback` | → `EscrowSubmitRecoveryScheduler` (직접 실행) |

Controller는 `CrudService` + `EscrowPaymentsService` 둘 다 주입받아 라우팅합니다.

### 테스트
- 단위: `makeCrudServiceTestingModule` / `makeProcessorTestingModule` 헬퍼 추가, 각 레이어 독립 테스트
- e2e: `escrow-rlusd-mock.e2e-spec.ts` 신규 추가 (MongoMemoryReplSet + mock XRPL)
- e2e: `escrow-rlusd-testnet.e2e-spec.ts` 신규 추가 (실제 testnet, `npm run test:e2e:rlusd-testnet`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Create API에 통화 옵션 추가: "XRP" 기본, "RLUSD" 선택 가능 (유효성 검사 포함)

* **개선사항**
  * RLUSD 지원 전반 추가: 신뢰선 관리, 잔액 검증 및 RLUSD 전송 흐름
  * 에스크로 제출/복구 및 처리 흐름 안정성 강화 (재시도·롤백·상태 전환 개선)

* **테스트**
  * RLUSD 관련 단위·통합·E2E 테스트 대폭 추가 및 실제 테스트넷 E2E 시나리오 포함

* **CI**
  * 실제 E2E 테스트(testnet) 단계 추가 및 최종 성공 메시지 간소화

* **오류 처리**
  * RLUSD 잔액 부족에 대한 명확한 400 응답 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->