### PR TITLE
[FEAT] 파트너 저장/삭제 및 검색 제외 처리

### DIFF
--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -15,3 +15,11 @@ export const CurrentUser = createParamDecorator(
     return { userId: req.session.userId, type: req.session.type };
   },
 );
+
+export const OptionalCurrentUser = createParamDecorator(
+  (_: unknown, ctx: ExecutionContext): SessionUser | null => {
+    const req = ctx.switchToHttp().getRequest();
+    if (!req.session?.userId || !req.session?.type) return null;
+    return { userId: req.session.userId, type: req.session.type };
+  },
+);

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -1,3 +1,4 @@
 export * from "./auth.exceptions";
 export * from "./escrow.exceptions";
+export * from "./my-business.exceptions";
 export * from "./xrpl.exceptions";

--- a/src/common/exceptions/my-business.exceptions.ts
+++ b/src/common/exceptions/my-business.exceptions.ts
@@ -1,0 +1,19 @@
+import { ConflictException, NotFoundException } from "@nestjs/common";
+
+export class PartnerAlreadySavedException extends ConflictException {
+  constructor() {
+    super("이미 저장된 파트너입니다.");
+  }
+}
+
+export class PartnerNotFoundException extends NotFoundException {
+  constructor() {
+    super("파트너를 찾을 수 없습니다.");
+  }
+}
+
+export class SavedPartnerNotFoundException extends NotFoundException {
+  constructor() {
+    super("저장된 파트너를 찾을 수 없습니다.");
+  }
+}

--- a/src/modules/my-business/dto/save-partner.dto.ts
+++ b/src/modules/my-business/dto/save-partner.dto.ts
@@ -1,0 +1,12 @@
+import { IsIn, IsMongoId } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class SavePartnerDto {
+  @ApiProperty({ description: "저장할 파트너 ID" })
+  @IsMongoId()
+  partnerId: string;
+
+  @ApiProperty({ enum: ["seller", "buyer"], description: "파트너 타입" })
+  @IsIn(["seller", "buyer"])
+  partnerType: "seller" | "buyer";
+}

--- a/src/modules/my-business/my-business.controller.ts
+++ b/src/modules/my-business/my-business.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Get, Query, UseGuards } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { MyBusinessService } from "./my-business.service";
 import { SessionGuard } from "../../common/guards/session.guard";
@@ -7,6 +16,7 @@ import {
   type SessionUser,
 } from "src/common/decorators/current-user.decorator";
 import { GetPartnersQueryDto } from "./dto/getPartnersQuery.dto";
+import { SavePartnerDto } from "./dto/save-partner.dto";
 
 @ApiTags("My Business")
 @Controller("my-business")
@@ -50,5 +60,29 @@ export class MyBusinessController {
   ) {
     const { page, limit } = query;
     return this.myBusinessService.getPartners(user.userId, page, limit);
+  }
+
+  @Post("partners")
+  @ApiOperation({ summary: "파트너 저장" })
+  @ApiResponse({ status: 201, description: "파트너 저장 성공" })
+  @ApiResponse({ status: 409, description: "이미 저장된 파트너" })
+  @ApiResponse({ status: 404, description: "파트너를 찾을 수 없음" })
+  savePartner(@CurrentUser() user: SessionUser, @Body() dto: SavePartnerDto) {
+    return this.myBusinessService.savePartner(
+      user.userId,
+      dto.partnerId,
+      dto.partnerType,
+    );
+  }
+
+  @Delete("partners/:partnerId")
+  @ApiOperation({ summary: "저장된 파트너 삭제" })
+  @ApiResponse({ status: 200, description: "파트너 삭제 성공" })
+  @ApiResponse({ status: 404, description: "저장된 파트너를 찾을 수 없음" })
+  removePartner(
+    @CurrentUser() user: SessionUser,
+    @Param("partnerId") partnerId: string,
+  ) {
+    return this.myBusinessService.removePartner(user.userId, partnerId);
   }
 }

--- a/src/modules/my-business/my-business.service.spec.ts
+++ b/src/modules/my-business/my-business.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { getModelToken } from "@nestjs/mongoose";
-import { NotFoundException } from "@nestjs/common";
+import { ConflictException, NotFoundException } from "@nestjs/common";
 import { Types } from "mongoose";
 import { MyBusinessService } from "./my-business.service";
 import { User } from "../users/schemas/user.schema";
@@ -13,16 +13,20 @@ const USER_ID = new Types.ObjectId().toString();
 
 const makeUserModel = (overrides = {}) => ({
   findById: jest.fn(),
+  exists: jest.fn(),
+  updateOne: jest.fn(),
   ...overrides,
 });
 
 const makeSellerModel = (overrides = {}) => ({
   find: jest.fn(),
+  exists: jest.fn(),
   ...overrides,
 });
 
 const makeBuyerModel = (overrides = {}) => ({
   find: jest.fn(),
+  exists: jest.fn(),
   ...overrides,
 });
 
@@ -86,6 +90,97 @@ describe("MyBusinessService", () => {
       await expect(service.getProfile(USER_ID)).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  // ── savePartner ───────────────────────────────────────────────────────────────
+
+  describe("savePartner", () => {
+    const PARTNER_ID = new Types.ObjectId().toString();
+
+    it("파트너 저장 성공", async () => {
+      userModel.exists.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+      sellerModel.exists.mockResolvedValue({ _id: PARTNER_ID });
+      userModel.updateOne.mockResolvedValue({ modifiedCount: 1 });
+
+      const result = await service.savePartner(USER_ID, PARTNER_ID, "seller");
+
+      expect(userModel.updateOne).toHaveBeenCalledWith(
+        { _id: USER_ID },
+        expect.objectContaining({ $push: expect.any(Object) }),
+      );
+      expect(result).toEqual({ message: "파트너가 저장되었습니다." });
+    });
+
+    it("이미 저장된 파트너 → ConflictException", async () => {
+      userModel.exists.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ _id: USER_ID }),
+      });
+
+      await expect(
+        service.savePartner(USER_ID, PARTNER_ID, "seller"),
+      ).rejects.toThrow(ConflictException);
+      expect(userModel.updateOne).not.toHaveBeenCalled();
+    });
+
+    it("존재하지 않는 파트너 ID → NotFoundException", async () => {
+      userModel.exists.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+      sellerModel.exists.mockResolvedValue(null);
+
+      await expect(
+        service.savePartner(USER_ID, PARTNER_ID, "seller"),
+      ).rejects.toThrow(NotFoundException);
+      expect(userModel.updateOne).not.toHaveBeenCalled();
+    });
+
+    it("buyer 파트너 저장 시 buyerModel.exists 호출", async () => {
+      userModel.exists.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+      buyerModel.exists.mockResolvedValue({ _id: PARTNER_ID });
+      userModel.updateOne.mockResolvedValue({ modifiedCount: 1 });
+
+      await service.savePartner(USER_ID, PARTNER_ID, "buyer");
+
+      expect(buyerModel.exists).toHaveBeenCalled();
+      expect(sellerModel.exists).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── removePartner ─────────────────────────────────────────────────────────────
+
+  describe("removePartner", () => {
+    const PARTNER_ID = new Types.ObjectId().toString();
+
+    it("파트너 삭제 성공", async () => {
+      userModel.updateOne.mockResolvedValue({ modifiedCount: 1 });
+
+      const result = await service.removePartner(USER_ID, PARTNER_ID);
+
+      expect(userModel.updateOne).toHaveBeenCalledWith(
+        { _id: USER_ID },
+        expect.objectContaining({ $pull: expect.any(Object) }),
+      );
+      expect(result).toEqual({ message: "파트너가 삭제되었습니다." });
+    });
+
+    it("저장되지 않은 파트너 삭제 → NotFoundException", async () => {
+      userModel.updateOne.mockResolvedValue({ modifiedCount: 0 });
+
+      await expect(service.removePartner(USER_ID, PARTNER_ID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("유효하지 않은 ObjectId → NotFoundException", async () => {
+      await expect(
+        service.removePartner(USER_ID, "not-a-valid-id"),
+      ).rejects.toThrow(NotFoundException);
+      expect(userModel.updateOne).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/my-business/my-business.service.spec.ts
+++ b/src/modules/my-business/my-business.service.spec.ts
@@ -99,36 +99,38 @@ describe("MyBusinessService", () => {
     const PARTNER_ID = new Types.ObjectId().toString();
 
     it("파트너 저장 성공", async () => {
-      userModel.exists.mockReturnValue({
-        lean: jest.fn().mockResolvedValue(null),
-      });
       sellerModel.exists.mockResolvedValue({ _id: PARTNER_ID });
-      userModel.updateOne.mockResolvedValue({ modifiedCount: 1 });
+      userModel.updateOne.mockResolvedValue({
+        matchedCount: 1,
+        modifiedCount: 1,
+      });
 
       const result = await service.savePartner(USER_ID, PARTNER_ID, "seller");
 
       expect(userModel.updateOne).toHaveBeenCalledWith(
-        { _id: USER_ID },
+        expect.objectContaining({
+          _id: USER_ID,
+          "savedPartners.partnerId": expect.any(Object),
+        }),
         expect.objectContaining({ $push: expect.any(Object) }),
       );
       expect(result).toEqual({ message: "파트너가 저장되었습니다." });
     });
 
     it("이미 저장된 파트너 → ConflictException", async () => {
-      userModel.exists.mockReturnValue({
-        lean: jest.fn().mockResolvedValue({ _id: USER_ID }),
+      sellerModel.exists.mockResolvedValue({ _id: PARTNER_ID });
+      userModel.updateOne.mockResolvedValue({
+        matchedCount: 0,
+        modifiedCount: 0,
       });
+      userModel.exists.mockResolvedValue({ _id: USER_ID });
 
       await expect(
         service.savePartner(USER_ID, PARTNER_ID, "seller"),
       ).rejects.toThrow(ConflictException);
-      expect(userModel.updateOne).not.toHaveBeenCalled();
     });
 
     it("존재하지 않는 파트너 ID → NotFoundException", async () => {
-      userModel.exists.mockReturnValue({
-        lean: jest.fn().mockResolvedValue(null),
-      });
       sellerModel.exists.mockResolvedValue(null);
 
       await expect(
@@ -138,11 +140,11 @@ describe("MyBusinessService", () => {
     });
 
     it("buyer 파트너 저장 시 buyerModel.exists 호출", async () => {
-      userModel.exists.mockReturnValue({
-        lean: jest.fn().mockResolvedValue(null),
-      });
       buyerModel.exists.mockResolvedValue({ _id: PARTNER_ID });
-      userModel.updateOne.mockResolvedValue({ modifiedCount: 1 });
+      userModel.updateOne.mockResolvedValue({
+        matchedCount: 1,
+        modifiedCount: 1,
+      });
 
       await service.savePartner(USER_ID, PARTNER_ID, "buyer");
 

--- a/src/modules/my-business/my-business.service.ts
+++ b/src/modules/my-business/my-business.service.ts
@@ -4,6 +4,11 @@ import { Model, Types } from "mongoose";
 import { User, UserDocument } from "../users/schemas/user.schema";
 import { Seller, SellerDocument } from "../sellers/schemas/seller.schema";
 import { Buyer, BuyerDocument } from "../buyers/schemas/buyer.schema";
+import {
+  PartnerAlreadySavedException,
+  PartnerNotFoundException,
+  SavedPartnerNotFoundException,
+} from "../../common/exceptions";
 
 @Injectable()
 export class MyBusinessService {
@@ -63,6 +68,45 @@ export class MyBusinessService {
 
     if (!user) throw new NotFoundException("사용자를 찾을 수 없습니다.");
     return user;
+  }
+
+  async savePartner(
+    userId: string,
+    partnerId: string,
+    partnerType: "seller" | "buyer",
+  ) {
+    const partnerObjectId = new Types.ObjectId(partnerId);
+
+    const alreadySaved = await this.userModel
+      .exists({ _id: userId, "savedPartners.partnerId": partnerObjectId })
+      .lean();
+    if (alreadySaved) throw new PartnerAlreadySavedException();
+
+    const model: Model<any> =
+      partnerType === "seller" ? this.sellerModel : this.buyerModel;
+    const exists = await model.exists({ _id: partnerObjectId });
+    if (!exists) throw new PartnerNotFoundException();
+
+    await this.userModel.updateOne(
+      { _id: userId },
+      { $push: { savedPartners: { partnerId: partnerObjectId, partnerType } } },
+    );
+    return { message: "파트너가 저장되었습니다." };
+  }
+
+  async removePartner(userId: string, partnerId: string) {
+    if (!Types.ObjectId.isValid(partnerId))
+      throw new SavedPartnerNotFoundException();
+
+    const result = await this.userModel.updateOne(
+      { _id: userId },
+      {
+        $pull: { savedPartners: { partnerId: new Types.ObjectId(partnerId) } },
+      },
+    );
+    if (result.modifiedCount === 0) throw new SavedPartnerNotFoundException();
+
+    return { message: "파트너가 삭제되었습니다." };
   }
 
   async getPartners(userId: string, page: number, limit: number) {

--- a/src/modules/my-business/my-business.service.ts
+++ b/src/modules/my-business/my-business.service.ts
@@ -75,22 +75,27 @@ export class MyBusinessService {
     partnerId: string,
     partnerType: "seller" | "buyer",
   ) {
-    const partnerObjectId = new Types.ObjectId(partnerId);
+    if (!Types.ObjectId.isValid(partnerId))
+      throw new SavedPartnerNotFoundException();
 
-    const alreadySaved = await this.userModel
-      .exists({ _id: userId, "savedPartners.partnerId": partnerObjectId })
-      .lean();
-    if (alreadySaved) throw new PartnerAlreadySavedException();
+    const partnerObjectId = new Types.ObjectId(partnerId);
 
     const model: Model<any> =
       partnerType === "seller" ? this.sellerModel : this.buyerModel;
     const exists = await model.exists({ _id: partnerObjectId });
     if (!exists) throw new PartnerNotFoundException();
 
-    await this.userModel.updateOne(
-      { _id: userId },
+    const result = await this.userModel.updateOne(
+      { _id: userId, "savedPartners.partnerId": { $ne: partnerObjectId } },
       { $push: { savedPartners: { partnerId: partnerObjectId, partnerType } } },
     );
+
+    if (result.matchedCount === 0) {
+      const userExists = await this.userModel.exists({ _id: userId });
+      if (!userExists)
+        throw new NotFoundException("사용자를 찾을 수 없습니다.");
+      throw new PartnerAlreadySavedException();
+    }
     return { message: "파트너가 저장되었습니다." };
   }
 

--- a/src/modules/partners/partners.controller.spec.ts
+++ b/src/modules/partners/partners.controller.spec.ts
@@ -32,13 +32,14 @@ describe("PartnersController", () => {
       };
       mockPartnersService.search.mockResolvedValue(result);
 
-      expect(await controller.search("acme", 10)).toEqual(result);
+      expect(await controller.search(null, "acme", 10)).toEqual(result);
     });
 
     it("모든 파라미터를 서비스에 전달", async () => {
       mockPartnersService.search.mockResolvedValue({ data: [] });
 
       await controller.search(
+        null,
         "acme",
         5,
         "Automotive",
@@ -62,7 +63,7 @@ describe("PartnersController", () => {
     it("파라미터 없이 호출 시 undefined 전달", async () => {
       mockPartnersService.search.mockResolvedValue({ data: [] });
 
-      await controller.search(undefined as any, 10);
+      await controller.search(null, undefined as any, 10);
 
       expect(mockPartnersService.search).toHaveBeenCalledWith(
         expect.objectContaining({ q: undefined, limit: 10 }),

--- a/src/modules/partners/partners.controller.ts
+++ b/src/modules/partners/partners.controller.ts
@@ -10,7 +10,7 @@ import { PartnersService } from "./partners.service";
 import {
   OptionalCurrentUser,
   type SessionUser,
-} from "src/common/decorators/current-user.decorator";
+} from "../../common/decorators/current-user.decorator";
 
 @ApiTags("Partners")
 @Controller("partners")

--- a/src/modules/partners/partners.controller.ts
+++ b/src/modules/partners/partners.controller.ts
@@ -7,6 +7,10 @@ import {
 } from "@nestjs/common";
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { PartnersService } from "./partners.service";
+import {
+  OptionalCurrentUser,
+  type SessionUser,
+} from "src/common/decorators/current-user.decorator";
 
 @ApiTags("Partners")
 @Controller("partners")
@@ -53,6 +57,7 @@ export class PartnersController {
     },
   })
   search(
+    @OptionalCurrentUser() user: SessionUser | null,
     @Query("q") q: string,
     @Query("limit", new DefaultValuePipe(10), ParseIntPipe) limit?: number,
     @Query("industry") industry?: string,
@@ -69,6 +74,7 @@ export class PartnersController {
       partnership,
       size,
       buyerId,
+      userId: user?.userId,
     });
   }
 }

--- a/src/modules/partners/partners.service.spec.ts
+++ b/src/modules/partners/partners.service.spec.ts
@@ -1,9 +1,13 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { getModelToken } from "@nestjs/mongoose";
+import { Types } from "mongoose";
 import { PartnersService } from "./partners.service";
 import { EmbeddingsService } from "../embeddings/embeddings.service";
 import { Seller } from "../sellers/schemas/seller.schema";
 import { Buyer } from "../buyers/schemas/buyer.schema";
+import { User } from "../users/schemas/user.schema";
+
+const USER_ID = new Types.ObjectId().toString();
 
 // Mongoose query는 exec() 없이 await 가능한 thenable → then/catch 추가
 function buildQueryMock(resolvedValue: any) {
@@ -33,6 +37,12 @@ const makeBuyerModel = () => ({
   countDocuments: jest.fn().mockResolvedValue(0),
 });
 
+const makeUserModel = () => ({
+  findById: jest.fn().mockReturnValue({
+    lean: jest.fn().mockResolvedValue(null),
+  }),
+});
+
 const makeEmbeddingsService = () => ({
   embed: jest.fn().mockResolvedValue([]),
 });
@@ -41,11 +51,13 @@ describe("PartnersService", () => {
   let service: PartnersService;
   let sellerModel: ReturnType<typeof makeSellerModel>;
   let buyerModel: ReturnType<typeof makeBuyerModel>;
+  let userModel: ReturnType<typeof makeUserModel>;
   let embeddingsService: ReturnType<typeof makeEmbeddingsService>;
 
   beforeEach(async () => {
     sellerModel = makeSellerModel();
     buyerModel = makeBuyerModel();
+    userModel = makeUserModel();
     embeddingsService = makeEmbeddingsService();
 
     const module: TestingModule = await Test.createTestingModule({
@@ -53,6 +65,7 @@ describe("PartnersService", () => {
         PartnersService,
         { provide: getModelToken(Seller.name), useValue: sellerModel },
         { provide: getModelToken(Buyer.name), useValue: buyerModel },
+        { provide: getModelToken(User.name), useValue: userModel },
         { provide: EmbeddingsService, useValue: embeddingsService },
       ],
     }).compile();
@@ -237,6 +250,86 @@ describe("PartnersService", () => {
 
       // 자동차 컨텍스트 없는 결과는 0.6 감점
       expect(result.data[0].score).toBeLessThan(0.5);
+    });
+  });
+
+  // ── savedPartners 제외 필터 ───────────────────────────────────────────────────
+
+  describe("savedPartners 제외 (로그인 사용자)", () => {
+    it("show-all 모드: savedPartners ID가 $nin 필터로 전달됨", async () => {
+      const savedId = new Types.ObjectId();
+      userModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          savedPartners: [{ partnerId: savedId, partnerType: "seller" }],
+        }),
+      });
+      sellerModel.find.mockReturnValue(buildQueryMock([]));
+
+      await service.search({ q: "", userId: USER_ID });
+
+      const [filterArg] = sellerModel.find.mock.calls[0];
+      expect(filterArg._id.$nin[0].toString()).toBe(savedId.toString());
+    });
+
+    it("browse 모드(필터만): savedPartners ID가 $nin 필터로 전달됨", async () => {
+      const savedId = new Types.ObjectId();
+      userModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          savedPartners: [{ partnerId: savedId, partnerType: "seller" }],
+        }),
+      });
+      sellerModel.find.mockReturnValue(
+        buildQueryMock([{ _id: new Types.ObjectId(), name: "다른 기업" }]),
+      );
+
+      await service.search({
+        q: "",
+        industry: "IT / AI / SaaS",
+        userId: USER_ID,
+      });
+
+      const [filterArg] = sellerModel.find.mock.calls[0];
+      expect(filterArg._id.$nin[0].toString()).toBe(savedId.toString());
+    });
+
+    it("텍스트 검색 모드: savedPartners ID가 $nin 필터로 전달됨", async () => {
+      const savedId = new Types.ObjectId();
+      userModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          savedPartners: [{ partnerId: savedId, partnerType: "seller" }],
+        }),
+      });
+      jest.spyOn(service as any, "generateHyDEAndKeywords").mockResolvedValue({
+        profile: "test",
+        keywords: "화장품",
+      });
+      embeddingsService.embed.mockResolvedValue([]);
+      sellerModel.find.mockReturnValue(buildQueryMock([]));
+
+      await service.search({ q: "화장품 제조사", userId: USER_ID });
+
+      const [filterArg] = sellerModel.find.mock.calls[0];
+      expect(filterArg._id.$nin[0].toString()).toBe(savedId.toString());
+    });
+
+    it("비로그인(userId 없음): userModel.findById 호출 안 함", async () => {
+      sellerModel.find.mockReturnValue(buildQueryMock([]));
+
+      await service.search({ q: "" });
+
+      expect(userModel.findById).not.toHaveBeenCalled();
+    });
+
+    it("savedPartners 없는 로그인 사용자: $nin 필터 적용 안 됨", async () => {
+      userModel.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ savedPartners: [] }),
+      });
+      sellerModel.find.mockReturnValue(buildQueryMock([]));
+
+      await service.search({ q: "", userId: USER_ID });
+
+      const [filterArg] = sellerModel.find.mock.calls[0];
+      expect(filterArg._id).toBeUndefined();
     });
   });
 });

--- a/src/modules/partners/partners.service.ts
+++ b/src/modules/partners/partners.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
-import { Model } from "mongoose";
+import { Model, Types } from "mongoose";
 import axios from "axios";
 import { Seller, SellerDocument } from "../sellers/schemas/seller.schema";
 import { Buyer, BuyerDocument } from "../buyers/schemas/buyer.schema";
+import { User, UserDocument } from "../users/schemas/user.schema";
 import { EmbeddingsService } from "../embeddings/embeddings.service";
 
 const INDUSTRY_MAPPING: Record<string, string[]> = {
@@ -53,6 +54,7 @@ export interface SearchOptions {
   partnership?: string;
   size?: string;
   buyerId?: string;
+  userId?: string;
 }
 
 export interface SearchResult {
@@ -104,6 +106,8 @@ export class PartnersService {
     private readonly sellerModel: Model<SellerDocument>,
     @InjectModel(Buyer.name)
     private readonly buyerModel: Model<BuyerDocument>,
+    @InjectModel(User.name)
+    private readonly userModel: Model<UserDocument>,
     private readonly embeddingsService: EmbeddingsService,
   ) {}
 
@@ -189,6 +193,17 @@ export class PartnersService {
       detectedIntent === "buyer" ? this.buyerModel : this.sellerModel;
     const isBuyerSearch = detectedIntent === "buyer";
 
+    // Exclude already-saved partners for logged-in users
+    const excludeObjectIds: Types.ObjectId[] = [];
+    if (opts.userId) {
+      const user = await this.userModel
+        .findById(opts.userId, { savedPartners: 1 })
+        .lean();
+      if (user?.savedPartners?.length) {
+        excludeObjectIds.push(...user.savedPartners.map((p) => p.partnerId));
+      }
+    }
+
     // --- 1. DB search (AI-Enhanced Parallel Hybrid) ---
     let vectorResults: any[] = [];
     let textResults: any[] = [];
@@ -208,7 +223,7 @@ export class PartnersService {
         `[Step 2.AI Analysis] took ${Math.round(performance.now() - aiStartTime)}ms. Keywords: "${aiKeywords}"`,
       );
 
-      // Define search tasks using AI output
+      // 텍스트 기반 검색
       const textSearchTask = (async () => {
         const textStartTime = performance.now();
         const filter: Record<string, any> = { $text: { $search: aiKeywords } };
@@ -243,6 +258,8 @@ export class PartnersService {
           if (isBuyerSearch) filter.country = country;
           else filter["location.country"] = country;
         }
+        if (excludeObjectIds.length > 0)
+          filter._id = { $nin: excludeObjectIds };
 
         const projection = isBuyerSearch
           ? {
@@ -325,6 +342,8 @@ export class PartnersService {
           if (isBuyerSearch) matchStage.country = country;
           else matchStage["location.country"] = country;
         }
+        if (excludeObjectIds.length > 0)
+          matchStage._id = { $nin: excludeObjectIds };
         if (Object.keys(matchStage).length > 0)
           pipeline.push({ $match: matchStage });
 
@@ -449,6 +468,7 @@ export class PartnersService {
         if (partnership) filter.tags = partnership;
         if (size) filter.sizeBucket = size;
       }
+      if (excludeObjectIds.length > 0) filter._id = { $nin: excludeObjectIds };
 
       const projection = isBuyerSearch
         ? {
@@ -494,7 +514,12 @@ export class PartnersService {
         : SEARCH_PROJECTION;
 
       const raw = await activeModel
-        .find({}, projection as any)
+        .find(
+          excludeObjectIds.length > 0
+            ? { _id: { $nin: excludeObjectIds } }
+            : {},
+          projection as any,
+        )
         .limit(Number(limit))
         .lean();
       dbResults = raw.map((r) => {


### PR DESCRIPTION
Resolves #18 

## 변경 사항

### My Business
- `POST /my-business/partners` — 파트너 저장 (seller/buyer 구분)
- `DELETE /my-business/partners/:partnerId` — 저장된 파트너 삭제
- 중복 저장 시 409, 존재하지 않는 파트너 저장 시 404 응답

### Partners 검색
- 로그인 사용자의 경우 이미 저장한 파트너를 검색 결과에서 자동 제외
- 비로그인 사용자는 기존과 동일하게 전체 결과 반환

### 기타
- `OptionalCurrentUser` 데코레이터 추가 (인증 선택적 엔드포인트용)
- my-business 도메인 커스텀 예외 클래스 분리 (`PartnerAlreadySavedException`, `PartnerNotFoundException`, `SavedPartnerNotFoundException`)

## 테스트
- `my-business.service.spec.ts` — savePartner / removePartner 케이스 추가
- `partners.service.spec.ts` — savedPartners $nin 필터 적용 케이스 추가 (로그인/비로그인/빈 목록)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 파트너를 저장하고 저장 목록에서 제거할 수 있는 기능이 추가되었습니다.
  * 파트너 검색 시 이미 저장된 파트너가 자동으로 제외됩니다.
  * 인증되지 않은 사용자도 파트너를 검색할 수 있도록 개선되었습니다.

* **테스트**
  * 파트너 저장/제거 및 검색 기능에 대한 테스트가 추가되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/K-Statra/backend/pull/23)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->