### PR TITLE
[FIX] 파트너 저장/삭제 API 및 에스크로 판매자 지갑 주소 조회

### DIFF
--- a/src/common/exceptions/escrow.exceptions.ts
+++ b/src/common/exceptions/escrow.exceptions.ts
@@ -102,3 +102,9 @@ export class PaymentInitiationFailedException extends InternalServerErrorExcepti
     super("Failed to initiate payment. Please try again.");
   }
 }
+
+export class SellerWalletNotFoundException extends NotFoundException {
+  constructor(walletAddress: string) {
+    super(`Seller with wallet address "${walletAddress}" not found`);
+  }
+}

--- a/src/modules/escrow-payments/__tests__/create.spec.ts
+++ b/src/modules/escrow-payments/__tests__/create.spec.ts
@@ -1,12 +1,22 @@
-import { BUYER_ID, SELLER_ID, makeCrudServiceTestingModule } from "./helpers";
-import { UnauthorizedPaymentActionException } from "../../../common/exceptions";
+import {
+  BUYER_ID,
+  SELLER_ID,
+  makeCrudServiceTestingModule,
+  makeQueryChain,
+} from "./helpers";
+import {
+  SellerWalletNotFoundException,
+  UnauthorizedPaymentActionException,
+} from "../../../common/exceptions";
+
+const SELLER_WALLET_ADDRESS = "rSellerAddress456";
 
 describe("EscrowPaymentsCrudService › create", () => {
   let ctx: Awaited<ReturnType<typeof makeCrudServiceTestingModule>>;
 
   const dto = {
     buyerId: BUYER_ID.toString(),
-    sellerId: SELLER_ID.toString(),
+    sellerWalletAddress: SELLER_WALLET_ADDRESS,
     memo: "수출 대금",
     escrows: [
       {
@@ -26,6 +36,8 @@ describe("EscrowPaymentsCrudService › create", () => {
 
   beforeEach(async () => {
     ctx = await makeCrudServiceTestingModule();
+    // 기본값: 지갑 주소로 seller 조회 성공
+    ctx.userModel.findOne.mockReturnValue(makeQueryChain({ _id: SELLER_ID }));
   });
 
   it("totalAmountXrp를 escrow 항목 합산으로 계산", async () => {
@@ -58,7 +70,27 @@ describe("EscrowPaymentsCrudService › create", () => {
     expect(instance.save).toHaveBeenCalled();
   });
 
-  it("참여자가 아닌 제3자 → UnauthorizedPaymentActionException", async () => {
+  it("wallet.address로 seller 조회 후 sellerId를 document에 주입", async () => {
+    await ctx.service.create(dto, BUYER_ID.toString());
+
+    expect(ctx.userModel.findOne).toHaveBeenCalledWith(
+      { "wallet.address": SELLER_WALLET_ADDRESS },
+      { _id: 1 },
+    );
+
+    const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
+    expect(constructorArg.sellerId.toString()).toBe(SELLER_ID.toString());
+  });
+
+  it("존재하지 않는 지갑 주소 → SellerWalletNotFoundException", async () => {
+    ctx.userModel.findOne.mockReturnValue(makeQueryChain(null));
+
+    await expect(ctx.service.create(dto, BUYER_ID.toString())).rejects.toThrow(
+      SellerWalletNotFoundException,
+    );
+  });
+
+  it("buyer가 아닌 제3자 → UnauthorizedPaymentActionException", async () => {
     await expect(
       ctx.service.create(dto, "000000000000000000000000"),
     ).rejects.toThrow(UnauthorizedPaymentActionException);

--- a/src/modules/escrow-payments/__tests__/create.spec.ts
+++ b/src/modules/escrow-payments/__tests__/create.spec.ts
@@ -74,7 +74,7 @@ describe("EscrowPaymentsCrudService › create", () => {
     await ctx.service.create(dto, BUYER_ID.toString());
 
     expect(ctx.userModel.findOne).toHaveBeenCalledWith(
-      { "wallet.address": SELLER_WALLET_ADDRESS },
+      { "wallet.address": SELLER_WALLET_ADDRESS, type: "seller" },
       { _id: 1 },
     );
 

--- a/src/modules/escrow-payments/__tests__/helpers.ts
+++ b/src/modules/escrow-payments/__tests__/helpers.ts
@@ -139,6 +139,7 @@ export function makeEscrowPaymentModelMock() {
 export function makeUserModelMock() {
   const ModelMock: any = jest.fn();
   ModelMock.findById = jest.fn().mockReturnValue(makeQueryChain(null));
+  ModelMock.findOne = jest.fn().mockReturnValue(makeQueryChain(null));
   return ModelMock;
 }
 
@@ -173,6 +174,7 @@ export function makeOutboxServiceMock() {
 
 export async function makeCrudServiceTestingModule() {
   const escrowPaymentModel = makeEscrowPaymentModelMock();
+  const userModel = makeUserModelMock();
 
   const module = await Test.createTestingModule({
     providers: [
@@ -181,12 +183,14 @@ export async function makeCrudServiceTestingModule() {
         provide: getModelToken(EscrowPayment.name),
         useValue: escrowPaymentModel,
       },
+      { provide: getModelToken(User.name), useValue: userModel },
     ],
   }).compile();
 
   return {
     service: module.get<EscrowPaymentsCrudService>(EscrowPaymentsCrudService),
     escrowPaymentModel,
+    userModel,
   };
 }
 

--- a/src/modules/escrow-payments/dto/create-escrow-payment.dto.ts
+++ b/src/modules/escrow-payments/dto/create-escrow-payment.dto.ts
@@ -10,6 +10,7 @@ import {
   IsOptional,
   IsPositive,
   IsString,
+  Matches,
   Min,
   ValidateNested,
 } from "class-validator";
@@ -48,11 +49,14 @@ export class CreateEscrowPaymentDto {
   buyerId: string;
 
   @ApiProperty({
-    description: "판매자 User ID (MongoDB ObjectId)",
-    example: "665f1a2b3c4d5e6f7a8b9c0e",
+    description: "판매자 XRPL 지갑 주소",
+    example: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
   })
-  @IsMongoId()
-  sellerId: string;
+  @IsString()
+  @Matches(/^r[1-9A-HJ-NP-Za-km-z]{24,33}$/, {
+    message: "sellerWalletAddress must be a valid XRPL address",
+  })
+  sellerWalletAddress: string;
 
   @ApiProperty({
     description: "결제 메모",

--- a/src/modules/escrow-payments/dto/create-escrow-payment.dto.ts
+++ b/src/modules/escrow-payments/dto/create-escrow-payment.dto.ts
@@ -53,7 +53,7 @@ export class CreateEscrowPaymentDto {
     example: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
   })
   @IsString()
-  @Matches(/^r[1-9A-HJ-NP-Za-km-z]{24,33}$/, {
+  @Matches(/^r[1-9A-HJ-NP-Za-km-z]{24,34}$/, {
     message: "sellerWalletAddress must be a valid XRPL address",
   })
   sellerWalletAddress: string;

--- a/src/modules/escrow-payments/escrow-payments-crud.service.ts
+++ b/src/modules/escrow-payments/escrow-payments-crud.service.ts
@@ -32,7 +32,10 @@ export class EscrowPaymentsCrudService {
     }
 
     const seller = await this.userModel
-      .findOne({ "wallet.address": dto.sellerWalletAddress }, { _id: 1 })
+      .findOne(
+        { "wallet.address": dto.sellerWalletAddress, type: "seller" },
+        { _id: 1 },
+      )
       .lean();
     if (!seller)
       throw new SellerWalletNotFoundException(dto.sellerWalletAddress);

--- a/src/modules/escrow-payments/escrow-payments-crud.service.ts
+++ b/src/modules/escrow-payments/escrow-payments-crud.service.ts
@@ -3,12 +3,14 @@ import { InjectModel } from "@nestjs/mongoose";
 import { Model, Types } from "mongoose";
 import {
   EscrowPaymentNotFoundException,
+  SellerWalletNotFoundException,
   UnauthorizedPaymentActionException,
 } from "../../common/exceptions";
 import {
   EscrowPayment,
   EscrowPaymentDocument,
 } from "./schemas/escrow-payment.schema";
+import { User, UserDocument } from "../users/schemas/user.schema";
 import { CreateEscrowPaymentDto } from "./dto/create-escrow-payment.dto";
 import { QueryEscrowPaymentDto } from "./dto/query-escrow-payment.dto";
 
@@ -17,21 +19,30 @@ export class EscrowPaymentsCrudService {
   constructor(
     @InjectModel(EscrowPayment.name)
     private readonly escrowPaymentModel: Model<EscrowPaymentDocument>,
+    @InjectModel(User.name)
+    private readonly userModel: Model<UserDocument>,
   ) {}
 
   async create(
     dto: CreateEscrowPaymentDto,
     userId: string,
   ): Promise<EscrowPaymentDocument> {
-    if (userId !== dto.buyerId && userId !== dto.sellerId) {
+    if (userId !== dto.buyerId) {
       throw new UnauthorizedPaymentActionException();
     }
 
+    const seller = await this.userModel
+      .findOne({ "wallet.address": dto.sellerWalletAddress }, { _id: 1 })
+      .lean();
+    if (!seller)
+      throw new SellerWalletNotFoundException(dto.sellerWalletAddress);
+
+    const sellerId = seller._id.toString();
     const totalAmountXrp = dto.escrows.reduce((sum, e) => sum + e.amountXrp, 0);
 
     const doc = new this.escrowPaymentModel({
       buyerId: new Types.ObjectId(dto.buyerId),
-      sellerId: new Types.ObjectId(dto.sellerId),
+      sellerId: new Types.ObjectId(sellerId),
       totalAmountXrp,
       currency: dto.currency ?? "XRP",
       memo: dto.memo ?? "",

--- a/test/escrow-mock.e2e-spec.ts
+++ b/test/escrow-mock.e2e-spec.ts
@@ -39,6 +39,9 @@ describe("EscrowPayments (e2e)", () => {
   const sellerObjectId = new Types.ObjectId();
   const nonParticipantId = new Types.ObjectId();
 
+  const BUYER_WALLET_ADDR = "rBuyerE2ETestAddress12345";
+  const SELLER_WALLET_ADDR = "rSe11erE2ETestAddress5678";
+
   // XrplService 전체를 모의 객체로 대체 (실제 XRPL 네트워크 호출 없음)
   const mockXrplService = {
     generateCryptoCondition: jest.fn(),
@@ -170,7 +173,7 @@ describe("EscrowPayments (e2e)", () => {
         industries: [],
         status: "ACTIVE",
         wallet: {
-          address: "rBuyerE2ETestAddr1234",
+          address: BUYER_WALLET_ADDR,
           seed: "enc:buyer_seed_plain",
           publicKey: "buyer_pub_key",
         },
@@ -187,7 +190,7 @@ describe("EscrowPayments (e2e)", () => {
         industries: [],
         status: "ACTIVE",
         wallet: {
-          address: "rSellerE2ETestAddr5678",
+          address: SELLER_WALLET_ADDR,
           seed: "enc:seller_seed_plain",
           publicKey: "seller_pub_key",
         },
@@ -258,7 +261,7 @@ describe("EscrowPayments (e2e)", () => {
   // 기본 생성 payload 헬퍼
   const baseCreatePayload = (overrides: object = {}) => ({
     buyerId: buyerObjectId.toString(),
-    sellerId: sellerObjectId.toString(),
+    sellerWalletAddress: SELLER_WALLET_ADDR,
     memo: "테스트 메모",
     escrows: [
       {
@@ -665,8 +668,8 @@ describe("EscrowPayments (e2e)", () => {
 
       expect(mockXrplService.createEscrow).toHaveBeenCalledTimes(1);
       expect(mockXrplService.createEscrow).toHaveBeenCalledWith(
-        expect.objectContaining({ address: "rBuyerE2ETestAddr1234" }),
-        "rSellerE2ETestAddr5678",
+        expect.objectContaining({ address: BUYER_WALLET_ADDR }),
+        SELLER_WALLET_ADDR,
         300,
         "A02580204ABCDEF",
         "XRP",
@@ -716,7 +719,7 @@ describe("EscrowPayments (e2e)", () => {
 
       expect(mockXrplService.validateEscrowFunds).toHaveBeenCalledTimes(1);
       expect(mockXrplService.validateEscrowFunds).toHaveBeenCalledWith(
-        "rBuyerE2ETestAddr1234",
+        BUYER_WALLET_ADDR,
         expect.arrayContaining([expect.objectContaining({ amountXrp: 300 })]),
       );
     });
@@ -791,8 +794,8 @@ describe("EscrowPayments (e2e)", () => {
 
       expect(mockXrplService.finishEscrow).toHaveBeenCalledTimes(1);
       expect(mockXrplService.finishEscrow).toHaveBeenCalledWith(
-        expect.objectContaining({ address: "rBuyerE2ETestAddr1234" }),
-        "rBuyerE2ETestAddr1234",
+        expect.objectContaining({ address: BUYER_WALLET_ADDR }),
+        BUYER_WALLET_ADDR,
         99999,
         "A02580204ABCDEF",
         expect.any(String),

--- a/test/escrow-rlusd-mock.e2e-spec.ts
+++ b/test/escrow-rlusd-mock.e2e-spec.ts
@@ -29,8 +29,8 @@ import { User } from "../src/modules/users/schemas/user.schema";
 import { HttpExceptionFilter } from "../src/common/filters/http-exception.filter";
 import { InsufficientRlusdBalanceException } from "../src/common/exceptions";
 
-const BUYER_ADDRESS = "rBuyerRlusdTestAddr";
-const SELLER_ADDRESS = "rSellerRlusdTestAddr";
+const BUYER_ADDRESS = "rBuyerR1usdTestAddress12345";
+const SELLER_ADDRESS = "rSe11erR1usdTestAddress5678";
 
 describe("RLUSD 에스크로 결제 (mock e2e)", () => {
   let app: INestApplication;
@@ -229,7 +229,7 @@ describe("RLUSD 에스크로 결제 (mock e2e)", () => {
 
   const rlusdCreatePayload = (overrides: object = {}) => ({
     buyerId: buyerObjectId.toString(),
-    sellerId: sellerObjectId.toString(),
+    sellerWalletAddress: SELLER_ADDRESS,
     memo: "RLUSD 테스트 결제",
     currency: "RLUSD",
     escrows: [
@@ -289,7 +289,7 @@ describe("RLUSD 에스크로 결제 (mock e2e)", () => {
         .set(asBuyer())
         .send({
           buyerId: buyerObjectId.toString(),
-          sellerId: sellerObjectId.toString(),
+          sellerWalletAddress: SELLER_ADDRESS,
           escrows: [
             {
               label: "초기금",

--- a/test/escrow-rlusd-testnet.e2e-spec.ts
+++ b/test/escrow-rlusd-testnet.e2e-spec.ts
@@ -105,6 +105,7 @@ describe("RLUSD 에스크로 결제 테스트넷 통합 테스트", () => {
 
   const buyerObjectId = new Types.ObjectId();
   const sellerObjectId = new Types.ObjectId();
+  let sellerWalletAddress: string;
 
   beforeAll(async () => {
     mongoServer = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
@@ -158,6 +159,7 @@ describe("RLUSD 에스크로 결제 테스트넷 통합 테스트", () => {
     // seller: Trust Line reserve(2 XRP) + 수수료 필요
     const buyerWallet = xrplService.generateWallet();
     const sellerWallet = xrplService.generateWallet();
+    sellerWalletAddress = sellerWallet.address;
 
     const issuerWallet = {
       address: issuerXrplWallet.address,
@@ -246,7 +248,7 @@ describe("RLUSD 에스크로 결제 테스트넷 통합 테스트", () => {
     const payment = await crudService.create(
       {
         buyerId: buyerObjectId.toString(),
-        sellerId: sellerObjectId.toString(),
+        sellerWalletAddress: sellerWalletAddress,
         memo: "테스트넷 TST 토큰 에스크로",
         currency: "RLUSD", // 서비스 분기 기준: RLUSD 코드 경로 사용
         escrows: [

--- a/test/escrow-testnet.e2e-spec.ts
+++ b/test/escrow-testnet.e2e-spec.ts
@@ -78,6 +78,7 @@ describe("XRPL Escrow Testnet (풀스택 통합 테스트)", () => {
   let crudService: EscrowPaymentsCrudService;
   let userModel: Model<User>;
   let buyerWalletAddress: string;
+  let sellerWalletAddress: string;
 
   const buyerObjectId = new Types.ObjectId();
   const sellerObjectId = new Types.ObjectId();
@@ -133,6 +134,7 @@ describe("XRPL Escrow Testnet (풀스택 통합 테스트)", () => {
     const buyerWallet = xrplService.generateWallet();
     const sellerWallet = xrplService.generateWallet();
     buyerWalletAddress = buyerWallet.address;
+    sellerWalletAddress = sellerWallet.address;
 
     await Promise.all([
       xrplService.fundAccount(buyerWallet),
@@ -191,7 +193,7 @@ describe("XRPL Escrow Testnet (풀스택 통합 테스트)", () => {
     const payment = await crudService.create(
       {
         buyerId: buyerObjectId.toString(),
-        sellerId: sellerObjectId.toString(),
+        sellerWalletAddress: sellerWalletAddress,
         memo: "테스트넷 초기금 에스크로",
         escrows: [
           {


### PR DESCRIPTION
Resolves #24 

## Summary

에스크로 결제 생성 시 `sellerId`를 직접 전달받는 대신, 판매자의 XRPL 지갑 주소로 seller를 조회하도록 변경

## Changes

- `CreateEscrowPaymentDto.sellerId` → `sellerWalletAddress` (XRPL Base58 주소 정규식 검증)
- `EscrowPaymentsCrudService.create()`: `wallet.address`로 seller DB 조회 후 `sellerId` 주입
- `SellerWalletNotFoundException` 추가 (지갑 주소에 해당하는 유저 없을 때 404)
- 결제 생성 권한 검사를 buyer 전용으로 단순화 (seller는 생성 주체가 아님)

## Why

프론트엔드가 상대방의 MongoDB ObjectId를 알 필요 없이, XRPL 지갑 주소만으로 에스크로 결제를 생성할 수 있도록 개선. 지갑 주소는 XRPL 상 고유값이므로 신뢰할 수 있는 조회 키로 활용 가능.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 판매자의 지갑 주소를 통한 판매자 확인 메커니즘이 추가되었습니다.
  * 판매자 지갑 주소가 존재하지 않을 경우 적절한 오류 처리가 구현되었습니다.

* **테스트**
  * 에스크로 결제 생성 기능에 대한 확장된 테스트 범위가 추가되었습니다.
  * 지갑 주소 조회 및 오류 처리 시나리오에 대한 테스트가 추가되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/K-Statra/backend/pull/25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->