### PR TITLE
[FEAT] 지갑 주소로 User 검색 API 추가

### DIFF
--- a/src/common/pipes/parse-xrpl-address.pipe.ts
+++ b/src/common/pipes/parse-xrpl-address.pipe.ts
@@ -1,0 +1,15 @@
+import { BadRequestException, Injectable, PipeTransform } from "@nestjs/common";
+
+const XRPL_ADDRESS_REGEX = /^r[1-9A-HJ-NP-Za-km-z]{24,34}$/;
+
+@Injectable()
+export class ParseXrplAddressPipe implements PipeTransform<string, string> {
+  transform(value: string): string {
+    if (!XRPL_ADDRESS_REGEX.test(value)) {
+      throw new BadRequestException(
+        `'${value}'은(는) 유효한 XRPL 지갑 주소가 아닙니다`,
+      );
+    }
+    return value;
+  }
+}

--- a/src/modules/escrow-payments/escrow-payments-crud.service.ts
+++ b/src/modules/escrow-payments/escrow-payments-crud.service.ts
@@ -122,4 +122,12 @@ export class EscrowPaymentsCrudService {
 
     return doc;
   }
+
+  async findUserByWalletAddress(walletAddress: string): Promise<UserDocument> {
+    const user = await this.userModel
+      .findOne({ "wallet.address": walletAddress })
+      .lean();
+    if (!user) throw new SellerWalletNotFoundException(walletAddress);
+    return user;
+  }
 }

--- a/src/modules/escrow-payments/escrow-payments.controller.ts
+++ b/src/modules/escrow-payments/escrow-payments.controller.ts
@@ -25,6 +25,7 @@ import {
   type SessionUser,
 } from "../../common/decorators/current-user.decorator";
 import { ParseMongoIdPipe } from "../../common/pipes/parse-mongo-id.pipe";
+import { ParseXrplAddressPipe } from "../../common/pipes/parse-xrpl-address.pipe";
 
 @ApiTags("Escrow Payments")
 @ApiCookieAuth()
@@ -35,6 +36,21 @@ export class EscrowPaymentsController {
     private readonly crudService: EscrowPaymentsCrudService,
     private readonly service: EscrowPaymentsService,
   ) {}
+
+  @Get("users/wallet/:address")
+  @ApiOperation({
+    summary: "지갑 주소로 유저 조회",
+    description: "XRPL 지갑 주소로 사용자 정보를 조회합니다.",
+  })
+  @ApiParam({ name: "address", description: "XRPL 지갑 주소" })
+  @ApiResponse({ status: 200, description: "조회 성공" })
+  @ApiResponse({ status: 400, description: "유효하지 않은 XRPL 지갑 주소" })
+  @ApiResponse({ status: 404, description: "해당 지갑 주소를 가진 유저 없음" })
+  findUserByWalletAddress(
+    @Param("address", ParseXrplAddressPipe) address: string,
+  ) {
+    return this.crudService.findUserByWalletAddress(address);
+  }
 
   @Get()
   @ApiOperation({


### PR DESCRIPTION
Resolves #26 

## 개요

결제내역 생성 전 지갑주소로 User 검색 및 검증 로직이 추가됨.

## 구현

1. 지갑 주소 검증용 Pipe 생성
2. service에 findUserByWalletAddress() 추가 (findOne)