### PR TITLE
[FEAT] 결제 내역 생성 시 Buyer는 자동 Approve

### DIFF
--- a/src/modules/escrow-payments/__tests__/create.spec.ts
+++ b/src/modules/escrow-payments/__tests__/create.spec.ts
@@ -61,6 +61,14 @@ describe("EscrowPaymentsCrudService › create", () => {
     expect(constructorArg.escrows[1].approvals).toHaveLength(2);
   });
 
+  it("생성자(buyer)의 buyerApproved를 true로 자동 설정", async () => {
+    await ctx.service.create(dto, BUYER_ID.toString());
+
+    const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
+    expect(constructorArg.buyerApproved).toBe(true);
+    expect(constructorArg.buyerApprovedAt).toBeInstanceOf(Date);
+  });
+
   it("save() 호출", async () => {
     const instance = { save: jest.fn().mockResolvedValue({}) };
     ctx.escrowPaymentModel.mockReturnValue(instance);

--- a/src/modules/escrow-payments/escrow-payments-crud.service.ts
+++ b/src/modules/escrow-payments/escrow-payments-crud.service.ts
@@ -43,10 +43,13 @@ export class EscrowPaymentsCrudService {
     const sellerId = seller._id.toString();
     const totalAmountXrp = dto.escrows.reduce((sum, e) => sum + e.amountXrp, 0);
 
+    const now = new Date();
     const doc = new this.escrowPaymentModel({
       buyerId: new Types.ObjectId(dto.buyerId),
       sellerId: new Types.ObjectId(sellerId),
       totalAmountXrp,
+      buyerApproved: true,
+      buyerApprovedAt: now,
       currency: dto.currency ?? "XRP",
       memo: dto.memo ?? "",
       escrows: dto.escrows.map((e) => ({

--- a/test/escrow-mock.e2e-spec.ts
+++ b/test/escrow-mock.e2e-spec.ts
@@ -297,9 +297,7 @@ describe("EscrowPayments (e2e)", () => {
     const paymentId: string = createRes.body._id;
     const escrowItemId: string = createRes.body.escrows[0]._id;
 
-    await request(app.getHttpServer())
-      .post(`/escrow-payments/${paymentId}/approve`)
-      .set(asBuyer());
+    // buyer는 생성 시 자동 승인되므로 seller만 승인하면 APPROVED
     await request(app.getHttpServer())
       .post(`/escrow-payments/${paymentId}/approve`)
       .set(asSeller());
@@ -351,7 +349,8 @@ describe("EscrowPayments (e2e)", () => {
       expect(res.body._id).toBeDefined();
       expect(res.body.status).toBe("DRAFT");
       expect(res.body.totalAmountXrp).toBe(500);
-      expect(res.body.buyerApproved).toBe(false);
+      expect(res.body.buyerApproved).toBe(true);
+      expect(res.body.buyerApprovedAt).toBeDefined();
       expect(res.body.sellerApproved).toBe(false);
     });
 
@@ -539,38 +538,31 @@ describe("EscrowPayments (e2e)", () => {
       paymentId = res.body._id;
     });
 
-    it("buyer 승인 → PENDING_APPROVAL, buyerApproved=true", async () => {
-      const res = await request(app.getHttpServer())
+    it("buyer 승인 시도 → 400 (생성 시 자동 승인됨)", async () => {
+      await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
         .set(asBuyer())
-        .expect(201);
-
-      expect(res.body.status).toBe("PENDING_APPROVAL");
-      expect(res.body.buyerApproved).toBe(true);
-      expect(res.body.sellerApproved).toBe(false);
+        .expect(400);
     });
 
-    it("seller 단독 승인 → PENDING_APPROVAL", async () => {
+    it("seller 승인 → APPROVED (buyer는 생성 시 자동 승인됨)", async () => {
       const res = await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
         .set(asSeller())
         .expect(201);
 
-      expect(res.body.status).toBe("PENDING_APPROVAL");
+      expect(res.body.status).toBe("APPROVED");
+      expect(res.body.buyerApproved).toBe(true);
       expect(res.body.sellerApproved).toBe(true);
     });
 
-    it("buyer + seller 모두 승인 → APPROVED (XRPL 미실행)", async () => {
-      await request(app.getHttpServer())
-        .post(`/escrow-payments/${paymentId}/approve`)
-        .set(asBuyer());
-
+    it("seller 승인만으로 APPROVED 전환 (XRPL 미실행)", async () => {
       const res = await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
         .set(asSeller())
         .expect(201);
 
-      // 양측 승인 → APPROVED, 아직 XRPL 에스크로 미실행
+      // buyer 자동 승인 + seller 승인 → APPROVED, 아직 XRPL 에스크로 미실행
       expect(res.body.status).toBe("APPROVED");
       expect(res.body.buyerApproved).toBe(true);
       expect(res.body.sellerApproved).toBe(true);
@@ -580,12 +572,12 @@ describe("EscrowPayments (e2e)", () => {
     it("동일 역할 중복 승인 → 400", async () => {
       await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
-        .set(asBuyer())
+        .set(asSeller())
         .expect(201);
 
       await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
-        .set(asBuyer())
+        .set(asSeller())
         .expect(400);
     });
 
@@ -599,15 +591,12 @@ describe("EscrowPayments (e2e)", () => {
     it("APPROVED 상태에서 승인 시도 → 400", async () => {
       await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
-        .set(asBuyer());
-      await request(app.getHttpServer())
-        .post(`/escrow-payments/${paymentId}/approve`)
         .set(asSeller());
-      // 이제 APPROVED — 추가 승인 불가
+      // seller 승인으로 APPROVED 전환 — 추가 승인 불가
 
       await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
-        .set(asBuyer())
+        .set(asSeller())
         .expect(400);
     });
   });
@@ -637,9 +626,7 @@ describe("EscrowPayments (e2e)", () => {
       paymentId = createRes.body._id;
       escrowItemId = createRes.body.escrows[0]._id;
 
-      await request(app.getHttpServer())
-        .post(`/escrow-payments/${paymentId}/approve`)
-        .set(asBuyer());
+      // buyer는 생성 시 자동 승인되므로 seller만 승인하면 APPROVED
       await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
         .set(asSeller());
@@ -847,10 +834,7 @@ describe("EscrowPayments (e2e)", () => {
       const freshId = freshRes.body._id;
       const freshEscrowId = freshRes.body.escrows[0]._id;
 
-      await request(app.getHttpServer())
-        .post(`/escrow-payments/${freshId}/approve`)
-        .set(asBuyer());
-      // seller 미승인 → PENDING_APPROVAL, 에스크로 항목 PENDING_ESCROW 유지
+      // seller 미승인 → 에스크로 항목 PENDING_ESCROW 유지
 
       await request(app.getHttpServer())
         .post(
@@ -879,9 +863,7 @@ describe("EscrowPayments (e2e)", () => {
       const twoPaymentId = twoEventRes.body._id;
       const twoEscrowId = twoEventRes.body.escrows[0]._id;
 
-      await request(app.getHttpServer())
-        .post(`/escrow-payments/${twoPaymentId}/approve`)
-        .set(asBuyer());
+      // buyer는 생성 시 자동 승인되므로 seller만 승인하면 APPROVED
       await request(app.getHttpServer())
         .post(`/escrow-payments/${twoPaymentId}/approve`)
         .set(asSeller());

--- a/test/escrow-mock.e2e-spec.ts
+++ b/test/escrow-mock.e2e-spec.ts
@@ -1020,9 +1020,6 @@ describe("EscrowPayments (e2e)", () => {
     it("ESCROWED 항목 취소 시도 → 400", async () => {
       await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
-        .set(asBuyer());
-      await request(app.getHttpServer())
-        .post(`/escrow-payments/${paymentId}/approve`)
         .set(asSeller());
       // POST /pay → PROCESSING → 비동기 EscrowCreate → ESCROWED
       await request(app.getHttpServer())

--- a/test/escrow-rlusd-mock.e2e-spec.ts
+++ b/test/escrow-rlusd-mock.e2e-spec.ts
@@ -254,9 +254,7 @@ describe("RLUSD 에스크로 결제 (mock e2e)", () => {
     const paymentId: string = createRes.body._id;
     const escrowItemId: string = createRes.body.escrows[0]._id;
 
-    await request(app.getHttpServer())
-      .post(`/escrow-payments/${paymentId}/approve`)
-      .set(asBuyer());
+    // buyer는 생성 시 자동 승인되므로 seller만 승인하면 APPROVED
     await request(app.getHttpServer())
       .post(`/escrow-payments/${paymentId}/approve`)
       .set(asSeller());
@@ -324,9 +322,7 @@ describe("RLUSD 에스크로 결제 (mock e2e)", () => {
         .expect(201);
       const paymentId = createRes.body._id;
 
-      await request(app.getHttpServer())
-        .post(`/escrow-payments/${paymentId}/approve`)
-        .set(asBuyer());
+      // buyer는 생성 시 자동 승인되므로 seller만 승인하면 APPROVED
       await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
         .set(asSeller());
@@ -354,9 +350,7 @@ describe("RLUSD 에스크로 결제 (mock e2e)", () => {
         .expect(201);
       const paymentId = createRes.body._id;
 
-      await request(app.getHttpServer())
-        .post(`/escrow-payments/${paymentId}/approve`)
-        .set(asBuyer());
+      // buyer는 생성 시 자동 승인되므로 seller만 승인하면 APPROVED
       await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
         .set(asSeller());
@@ -381,9 +375,7 @@ describe("RLUSD 에스크로 결제 (mock e2e)", () => {
         .expect(201);
       const paymentId = createRes.body._id;
 
-      await request(app.getHttpServer())
-        .post(`/escrow-payments/${paymentId}/approve`)
-        .set(asBuyer());
+      // buyer는 생성 시 자동 승인되므로 seller만 승인하면 APPROVED
       await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
         .set(asSeller());

--- a/test/escrow-rlusd-testnet.e2e-spec.ts
+++ b/test/escrow-rlusd-testnet.e2e-spec.ts
@@ -8,8 +8,8 @@
  *   issuer 지갑 → buyer/seller에게 trust line 설정 → issuer가 buyer에게 토큰 전송
  *
  * 플로우:
- *   1. 결제 생성 (currency: RLUSD)
- *   2. 양측 승인 → APPROVED
+ *   1. 결제 생성 (currency: RLUSD, buyer 자동 승인)
+ *   2. seller 승인 → APPROVED
  *   3. 결제 개시 → trust line 자동 확인 + 잔고 검증 → PROCESSING + Outbox
  *   4. OutboxWatcher → EscrowCreateProcessor → XLS-85 EscrowCreate → ESCROWED → ACTIVE
  *   5. 이벤트 2개 양방향 승인 → EscrowFinish → RELEASED / COMPLETED
@@ -267,13 +267,11 @@ describe("RLUSD 에스크로 결제 테스트넷 통합 테스트", () => {
     const escrowItemId = payment.escrows[0]._id.toString();
 
     expect(payment.status).toBe("DRAFT");
+    expect(payment.buyerApproved).toBe(true);
+    expect(payment.buyerApprovedAt).toBeDefined();
     expect(payment.currency).toBe("RLUSD");
 
-    // ── 2. 양측 승인 → APPROVED ──────────────────────────────────────────
-    await escrowPaymentsService.approvePayment(
-      paymentId,
-      buyerObjectId.toString(),
-    );
+    // ── 2. seller 승인 → APPROVED (buyer는 생성 시 자동 승인) ─────────────
     const afterApprove = await escrowPaymentsService.approvePayment(
       paymentId,
       sellerObjectId.toString(),

--- a/test/escrow-testnet.e2e-spec.ts
+++ b/test/escrow-testnet.e2e-spec.ts
@@ -4,8 +4,8 @@
  * 실제 XRPL testnet + MongoMemoryReplSet + 실제 Redis(Bull Queue) + OutboxWatcherService(Change Streams)
  * 로 전체 에스크로 결제 플로우를 검증합니다:
  *
- *   1. 결제 내역 생성
- *   2. 양측(buyer / seller) 승인 → APPROVED
+ *   1. 결제 내역 생성 (buyer 자동 승인)
+ *   2. seller 승인 → APPROVED
  *   3. 결제 개시 → PROCESSING + Outbox 이벤트 MongoDB 기록 (트랜잭션)
  *   4. OutboxWatcherService(Change Streams) → Bull Queue → EscrowCreateProcessor → XRPL EscrowCreate → ESCROWED → ACTIVE
  *   5. 이벤트1 buyer 승인 → ESCROWED 유지 (seller 미승인)
@@ -211,6 +211,8 @@ describe("XRPL Escrow Testnet (풀스택 통합 테스트)", () => {
     const escrowItemId = payment.escrows[0]._id.toString();
 
     expect(payment.status).toBe("DRAFT");
+    expect(payment.buyerApproved).toBe(true);
+    expect(payment.buyerApprovedAt).toBeDefined();
     expect(payment.totalAmountXrp).toBe(10);
     expect(payment.escrows).toHaveLength(1);
     expect(payment.escrows[0].amountXrp).toBe(10);
@@ -221,11 +223,7 @@ describe("XRPL Escrow Testnet (풀스택 통합 테스트)", () => {
       ),
     ).toBe(true);
 
-    // ── 2. 결제 양측 승인 → APPROVED (XRPL 미실행) ───────────────────────
-    await escrowPaymentsService.approvePayment(
-      paymentId,
-      buyerObjectId.toString(),
-    );
+    // ── 2. 결제 승인 → APPROVED (buyer는 생성 시 자동 승인, seller만 호출)
     const afterBothApprove = await escrowPaymentsService.approvePayment(
       paymentId,
       sellerObjectId.toString(),


### PR DESCRIPTION
## 개요

결제 내역 생성 시 Buyer가 승인할 필요 없이 생성 시 승인되도록 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 에스크로우 결제 생성 시 구매자가 자동으로 승인됩니다. 승인 타임스탬프가 함께 기록됩니다.

* **개선사항**
  * 결제 승인 프로세스가 단순화되었으며, 이제 판매자 승인만으로 거래가 완료됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/K-Statra/backend/pull/28)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->