### PR TITLE
[FEAT] 에스크로 결제 생성/승인 양방향 지원 및 파트너 관리 API 추가

### DIFF
--- a/src/common/exceptions/escrow.exceptions.ts
+++ b/src/common/exceptions/escrow.exceptions.ts
@@ -108,3 +108,9 @@ export class SellerWalletNotFoundException extends NotFoundException {
     super(`Seller with wallet address "${walletAddress}" not found`);
   }
 }
+
+export class BuyerWalletNotFoundException extends NotFoundException {
+  constructor(walletAddress: string) {
+    super(`Buyer with wallet address "${walletAddress}" not found`);
+  }
+}

--- a/src/modules/escrow-payments/__tests__/approval.spec.ts
+++ b/src/modules/escrow-payments/__tests__/approval.spec.ts
@@ -35,74 +35,73 @@ describe("EscrowPaymentsService › approvePayment", () => {
     ctx = await makeServiceTestingModule();
   });
 
-  it("buyer 최초 승인 → PENDING_APPROVAL, buyerApproved=true", async () => {
-    const payment = makePayment({ status: "DRAFT" });
-    ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
+  // ── buyer가 생성한 결제 (buyerApproved=true 자동 설정) ──────────────────────
 
-    await ctx.service.approvePayment(
-      PAYMENT_ID.toString(),
-      BUYER_ID.toString(),
-    );
+  describe("buyer가 생성한 결제", () => {
+    it("seller 승인 → APPROVED, sellerApproved=true", async () => {
+      const payment = makePayment({
+        status: "DRAFT",
+        buyerApproved: true,
+        buyerApprovedAt: new Date(),
+      });
+      ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
 
-    expect(payment.buyerApproved).toBe(true);
-    expect(payment.buyerApprovedAt).toBeInstanceOf(Date);
-    expect(payment.status).toBe("PENDING_APPROVAL");
-    expect(payment.save).toHaveBeenCalled();
-  });
+      await ctx.service.approvePayment(
+        PAYMENT_ID.toString(),
+        SELLER_ID.toString(),
+      );
 
-  it("seller 최초 승인 → PENDING_APPROVAL, sellerApproved=true", async () => {
-    const payment = makePayment({ status: "DRAFT" });
-    ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
-
-    await ctx.service.approvePayment(
-      PAYMENT_ID.toString(),
-      SELLER_ID.toString(),
-    );
-
-    expect(payment.sellerApproved).toBe(true);
-    expect(payment.status).toBe("PENDING_APPROVAL");
-  });
-
-  it("양측 모두 승인 → APPROVED", async () => {
-    const payment = makePayment({
-      status: "PENDING_APPROVAL",
-      buyerApproved: true,
-      buyerApprovedAt: new Date(),
+      expect(payment.sellerApproved).toBe(true);
+      expect(payment.sellerApprovedAt).toBeInstanceOf(Date);
+      expect(payment.status).toBe("APPROVED");
+      expect(payment.save).toHaveBeenCalled();
     });
-    ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
 
-    await ctx.service.approvePayment(
-      PAYMENT_ID.toString(),
-      SELLER_ID.toString(),
-    );
+    it("buyer 중복 승인 → AlreadyApprovedPaymentException, save 미호출", async () => {
+      const payment = makePayment({ status: "DRAFT", buyerApproved: true });
+      ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
 
-    expect(payment.status).toBe("APPROVED");
-  });
-
-  it("buyer 중복 승인 → AlreadyApprovedPaymentException, save 미호출", async () => {
-    const payment = makePayment({
-      status: "PENDING_APPROVAL",
-      buyerApproved: true,
+      await expect(
+        ctx.service.approvePayment(PAYMENT_ID.toString(), BUYER_ID.toString()),
+      ).rejects.toThrow(AlreadyApprovedPaymentException);
+      expect(payment.save).not.toHaveBeenCalled();
     });
-    ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
-
-    await expect(
-      ctx.service.approvePayment(PAYMENT_ID.toString(), BUYER_ID.toString()),
-    ).rejects.toThrow(AlreadyApprovedPaymentException);
-    expect(payment.save).not.toHaveBeenCalled();
   });
 
-  it("seller 중복 승인 → AlreadyApprovedPaymentException", async () => {
-    const payment = makePayment({
-      status: "PENDING_APPROVAL",
-      sellerApproved: true,
+  // ── seller가 생성한 결제 (sellerApproved=true 자동 설정) ────────────────────
+
+  describe("seller가 생성한 결제", () => {
+    it("buyer 승인 → APPROVED, buyerApproved=true", async () => {
+      const payment = makePayment({
+        status: "DRAFT",
+        sellerApproved: true,
+        sellerApprovedAt: new Date(),
+      });
+      ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
+
+      await ctx.service.approvePayment(
+        PAYMENT_ID.toString(),
+        BUYER_ID.toString(),
+      );
+
+      expect(payment.buyerApproved).toBe(true);
+      expect(payment.buyerApprovedAt).toBeInstanceOf(Date);
+      expect(payment.status).toBe("APPROVED");
+      expect(payment.save).toHaveBeenCalled();
     });
-    ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
 
-    await expect(
-      ctx.service.approvePayment(PAYMENT_ID.toString(), SELLER_ID.toString()),
-    ).rejects.toThrow(AlreadyApprovedPaymentException);
+    it("seller 중복 승인 → AlreadyApprovedPaymentException, save 미호출", async () => {
+      const payment = makePayment({ status: "DRAFT", sellerApproved: true });
+      ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
+
+      await expect(
+        ctx.service.approvePayment(PAYMENT_ID.toString(), SELLER_ID.toString()),
+      ).rejects.toThrow(AlreadyApprovedPaymentException);
+      expect(payment.save).not.toHaveBeenCalled();
+    });
   });
+
+  // ── 공통 ────────────────────────────────────────────────────────────────────
 
   it("ACTIVE 상태에서 승인 시도 → InvalidPaymentStatusException", async () => {
     const payment = makePayment({ status: "ACTIVE" });

--- a/src/modules/escrow-payments/__tests__/create.spec.ts
+++ b/src/modules/escrow-payments/__tests__/create.spec.ts
@@ -13,7 +13,7 @@ import {
 const SELLER_WALLET_ADDRESS = "rSellerAddress456";
 const BUYER_WALLET_ADDRESS = "rBuyerAddress123";
 
-const escrows = [
+const makeEscrows = () => [
   {
     label: "초기금",
     amountXrp: 300,
@@ -34,11 +34,11 @@ describe("EscrowPaymentsCrudService › create", () => {
   // ── buyer가 생성 ──────────────────────────────────────────────────────────
 
   describe("buyer가 생성", () => {
-    const dto = {
+    const makeDto = () => ({
       counterpartyWalletAddress: SELLER_WALLET_ADDRESS,
       memo: "수출 대금",
-      escrows,
-    };
+      escrows: makeEscrows(),
+    });
 
     beforeEach(async () => {
       ctx = await makeCrudServiceTestingModule();
@@ -47,14 +47,14 @@ describe("EscrowPaymentsCrudService › create", () => {
     });
 
     it("totalAmountXrp를 escrow 항목 합산으로 계산", async () => {
-      await ctx.service.create(dto, BUYER_ID.toString());
+      await ctx.service.create(makeDto(), BUYER_ID.toString());
 
       const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
       expect(constructorArg.totalAmountXrp).toBe(1000);
     });
 
     it("각 escrow 항목의 approvals를 requiredEventTypes로 초기화", async () => {
-      await ctx.service.create(dto, BUYER_ID.toString());
+      await ctx.service.create(makeDto(), BUYER_ID.toString());
 
       const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
       expect(constructorArg.escrows[0].approvals).toEqual([
@@ -68,7 +68,7 @@ describe("EscrowPaymentsCrudService › create", () => {
     });
 
     it("생성자(buyer)의 buyerApproved를 true로 자동 설정", async () => {
-      await ctx.service.create(dto, BUYER_ID.toString());
+      await ctx.service.create(makeDto(), BUYER_ID.toString());
 
       const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
       expect(constructorArg.buyerApproved).toBe(true);
@@ -80,13 +80,13 @@ describe("EscrowPaymentsCrudService › create", () => {
       const instance = { save: jest.fn().mockResolvedValue({}) };
       ctx.escrowPaymentModel.mockReturnValue(instance);
 
-      await ctx.service.create(dto, BUYER_ID.toString());
+      await ctx.service.create(makeDto(), BUYER_ID.toString());
 
       expect(instance.save).toHaveBeenCalled();
     });
 
     it("counterpartyWalletAddress로 seller 조회 후 sellerId를 document에 주입", async () => {
-      await ctx.service.create(dto, BUYER_ID.toString());
+      await ctx.service.create(makeDto(), BUYER_ID.toString());
 
       expect(ctx.userModel.findOne).toHaveBeenCalledWith(
         { "wallet.address": SELLER_WALLET_ADDRESS, type: "seller" },
@@ -101,7 +101,7 @@ describe("EscrowPaymentsCrudService › create", () => {
       ctx.userModel.findOne.mockReturnValue(makeQueryChain(null));
 
       await expect(
-        ctx.service.create(dto, BUYER_ID.toString()),
+        ctx.service.create(makeDto(), BUYER_ID.toString()),
       ).rejects.toThrow(SellerWalletNotFoundException);
     });
   });
@@ -109,11 +109,11 @@ describe("EscrowPaymentsCrudService › create", () => {
   // ── seller가 생성 ──────────────────────────────────────────────────────────
 
   describe("seller가 생성", () => {
-    const dto = {
+    const makeDto = () => ({
       counterpartyWalletAddress: BUYER_WALLET_ADDRESS,
       memo: "수출 대금",
-      escrows,
-    };
+      escrows: makeEscrows(),
+    });
 
     beforeEach(async () => {
       ctx = await makeCrudServiceTestingModule();
@@ -124,7 +124,7 @@ describe("EscrowPaymentsCrudService › create", () => {
     });
 
     it("생성자(seller)의 sellerApproved를 true로 자동 설정", async () => {
-      await ctx.service.create(dto, SELLER_ID.toString());
+      await ctx.service.create(makeDto(), SELLER_ID.toString());
 
       const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
       expect(constructorArg.sellerApproved).toBe(true);
@@ -133,7 +133,7 @@ describe("EscrowPaymentsCrudService › create", () => {
     });
 
     it("counterpartyWalletAddress로 buyer 조회 후 buyerId를 document에 주입", async () => {
-      await ctx.service.create(dto, SELLER_ID.toString());
+      await ctx.service.create(makeDto(), SELLER_ID.toString());
 
       expect(ctx.userModel.findOne).toHaveBeenCalledWith(
         { "wallet.address": BUYER_WALLET_ADDRESS, type: "buyer" },
@@ -148,7 +148,7 @@ describe("EscrowPaymentsCrudService › create", () => {
       ctx.userModel.findOne.mockReturnValue(makeQueryChain(null));
 
       await expect(
-        ctx.service.create(dto, SELLER_ID.toString()),
+        ctx.service.create(makeDto(), SELLER_ID.toString()),
       ).rejects.toThrow(BuyerWalletNotFoundException);
     });
   });
@@ -161,7 +161,10 @@ describe("EscrowPaymentsCrudService › create", () => {
 
     await expect(
       ctx.service.create(
-        { counterpartyWalletAddress: SELLER_WALLET_ADDRESS, escrows },
+        {
+          counterpartyWalletAddress: SELLER_WALLET_ADDRESS,
+          escrows: makeEscrows(),
+        },
         "000000000000000000000000",
       ),
     ).rejects.toThrow(UnauthorizedPaymentActionException);

--- a/src/modules/escrow-payments/__tests__/create.spec.ts
+++ b/src/modules/escrow-payments/__tests__/create.spec.ts
@@ -5,102 +5,165 @@ import {
   makeQueryChain,
 } from "./helpers";
 import {
+  BuyerWalletNotFoundException,
   SellerWalletNotFoundException,
   UnauthorizedPaymentActionException,
 } from "../../../common/exceptions";
 
 const SELLER_WALLET_ADDRESS = "rSellerAddress456";
+const BUYER_WALLET_ADDRESS = "rBuyerAddress123";
+
+const escrows = [
+  {
+    label: "초기금",
+    amountXrp: 300,
+    order: 0,
+    requiredEventTypes: ["SHIPMENT_CONFIRMED"],
+  },
+  {
+    label: "잔금",
+    amountXrp: 700,
+    order: 1,
+    requiredEventTypes: ["DELIVERY_CONFIRMED", "INSPECTION_PASSED"],
+  },
+];
 
 describe("EscrowPaymentsCrudService › create", () => {
   let ctx: Awaited<ReturnType<typeof makeCrudServiceTestingModule>>;
 
-  const dto = {
-    buyerId: BUYER_ID.toString(),
-    sellerWalletAddress: SELLER_WALLET_ADDRESS,
-    memo: "수출 대금",
-    escrows: [
-      {
-        label: "초기금",
-        amountXrp: 300,
-        order: 0,
-        requiredEventTypes: ["SHIPMENT_CONFIRMED"],
-      },
-      {
-        label: "잔금",
-        amountXrp: 700,
-        order: 1,
-        requiredEventTypes: ["DELIVERY_CONFIRMED", "INSPECTION_PASSED"],
-      },
-    ],
-  };
+  // ── buyer가 생성 ──────────────────────────────────────────────────────────
 
-  beforeEach(async () => {
+  describe("buyer가 생성", () => {
+    const dto = {
+      counterpartyWalletAddress: SELLER_WALLET_ADDRESS,
+      memo: "수출 대금",
+      escrows,
+    };
+
+    beforeEach(async () => {
+      ctx = await makeCrudServiceTestingModule();
+      ctx.userModel.findById.mockReturnValue(makeQueryChain({ type: "buyer" }));
+      ctx.userModel.findOne.mockReturnValue(makeQueryChain({ _id: SELLER_ID }));
+    });
+
+    it("totalAmountXrp를 escrow 항목 합산으로 계산", async () => {
+      await ctx.service.create(dto, BUYER_ID.toString());
+
+      const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
+      expect(constructorArg.totalAmountXrp).toBe(1000);
+    });
+
+    it("각 escrow 항목의 approvals를 requiredEventTypes로 초기화", async () => {
+      await ctx.service.create(dto, BUYER_ID.toString());
+
+      const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
+      expect(constructorArg.escrows[0].approvals).toEqual([
+        expect.objectContaining({
+          eventType: "SHIPMENT_CONFIRMED",
+          buyerApproved: false,
+          sellerApproved: false,
+        }),
+      ]);
+      expect(constructorArg.escrows[1].approvals).toHaveLength(2);
+    });
+
+    it("생성자(buyer)의 buyerApproved를 true로 자동 설정", async () => {
+      await ctx.service.create(dto, BUYER_ID.toString());
+
+      const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
+      expect(constructorArg.buyerApproved).toBe(true);
+      expect(constructorArg.buyerApprovedAt).toBeInstanceOf(Date);
+      expect(constructorArg.sellerApproved).toBe(false);
+    });
+
+    it("save() 호출", async () => {
+      const instance = { save: jest.fn().mockResolvedValue({}) };
+      ctx.escrowPaymentModel.mockReturnValue(instance);
+
+      await ctx.service.create(dto, BUYER_ID.toString());
+
+      expect(instance.save).toHaveBeenCalled();
+    });
+
+    it("counterpartyWalletAddress로 seller 조회 후 sellerId를 document에 주입", async () => {
+      await ctx.service.create(dto, BUYER_ID.toString());
+
+      expect(ctx.userModel.findOne).toHaveBeenCalledWith(
+        { "wallet.address": SELLER_WALLET_ADDRESS, type: "seller" },
+        { _id: 1 },
+      );
+
+      const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
+      expect(constructorArg.sellerId.toString()).toBe(SELLER_ID.toString());
+    });
+
+    it("존재하지 않는 seller 지갑 주소 → SellerWalletNotFoundException", async () => {
+      ctx.userModel.findOne.mockReturnValue(makeQueryChain(null));
+
+      await expect(
+        ctx.service.create(dto, BUYER_ID.toString()),
+      ).rejects.toThrow(SellerWalletNotFoundException);
+    });
+  });
+
+  // ── seller가 생성 ──────────────────────────────────────────────────────────
+
+  describe("seller가 생성", () => {
+    const dto = {
+      counterpartyWalletAddress: BUYER_WALLET_ADDRESS,
+      memo: "수출 대금",
+      escrows,
+    };
+
+    beforeEach(async () => {
+      ctx = await makeCrudServiceTestingModule();
+      ctx.userModel.findById.mockReturnValue(
+        makeQueryChain({ type: "seller" }),
+      );
+      ctx.userModel.findOne.mockReturnValue(makeQueryChain({ _id: BUYER_ID }));
+    });
+
+    it("생성자(seller)의 sellerApproved를 true로 자동 설정", async () => {
+      await ctx.service.create(dto, SELLER_ID.toString());
+
+      const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
+      expect(constructorArg.sellerApproved).toBe(true);
+      expect(constructorArg.sellerApprovedAt).toBeInstanceOf(Date);
+      expect(constructorArg.buyerApproved).toBe(false);
+    });
+
+    it("counterpartyWalletAddress로 buyer 조회 후 buyerId를 document에 주입", async () => {
+      await ctx.service.create(dto, SELLER_ID.toString());
+
+      expect(ctx.userModel.findOne).toHaveBeenCalledWith(
+        { "wallet.address": BUYER_WALLET_ADDRESS, type: "buyer" },
+        { _id: 1 },
+      );
+
+      const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
+      expect(constructorArg.buyerId.toString()).toBe(BUYER_ID.toString());
+    });
+
+    it("존재하지 않는 buyer 지갑 주소 → BuyerWalletNotFoundException", async () => {
+      ctx.userModel.findOne.mockReturnValue(makeQueryChain(null));
+
+      await expect(
+        ctx.service.create(dto, SELLER_ID.toString()),
+      ).rejects.toThrow(BuyerWalletNotFoundException);
+    });
+  });
+
+  // ── 공통 ──────────────────────────────────────────────────────────────────
+
+  it("DB에 없는 userId → UnauthorizedPaymentActionException", async () => {
     ctx = await makeCrudServiceTestingModule();
-    // 기본값: 지갑 주소로 seller 조회 성공
-    ctx.userModel.findOne.mockReturnValue(makeQueryChain({ _id: SELLER_ID }));
-  });
+    // findById 기본값: null (makeUserModelMock 참고)
 
-  it("totalAmountXrp를 escrow 항목 합산으로 계산", async () => {
-    await ctx.service.create(dto, BUYER_ID.toString());
-
-    const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
-    expect(constructorArg.totalAmountXrp).toBe(1000);
-  });
-
-  it("각 escrow 항목의 approvals를 requiredEventTypes로 초기화", async () => {
-    await ctx.service.create(dto, BUYER_ID.toString());
-
-    const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
-    expect(constructorArg.escrows[0].approvals).toEqual([
-      expect.objectContaining({
-        eventType: "SHIPMENT_CONFIRMED",
-        buyerApproved: false,
-        sellerApproved: false,
-      }),
-    ]);
-    expect(constructorArg.escrows[1].approvals).toHaveLength(2);
-  });
-
-  it("생성자(buyer)의 buyerApproved를 true로 자동 설정", async () => {
-    await ctx.service.create(dto, BUYER_ID.toString());
-
-    const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
-    expect(constructorArg.buyerApproved).toBe(true);
-    expect(constructorArg.buyerApprovedAt).toBeInstanceOf(Date);
-  });
-
-  it("save() 호출", async () => {
-    const instance = { save: jest.fn().mockResolvedValue({}) };
-    ctx.escrowPaymentModel.mockReturnValue(instance);
-
-    await ctx.service.create(dto, BUYER_ID.toString());
-
-    expect(instance.save).toHaveBeenCalled();
-  });
-
-  it("wallet.address로 seller 조회 후 sellerId를 document에 주입", async () => {
-    await ctx.service.create(dto, BUYER_ID.toString());
-
-    expect(ctx.userModel.findOne).toHaveBeenCalledWith(
-      { "wallet.address": SELLER_WALLET_ADDRESS, type: "seller" },
-      { _id: 1 },
-    );
-
-    const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
-    expect(constructorArg.sellerId.toString()).toBe(SELLER_ID.toString());
-  });
-
-  it("존재하지 않는 지갑 주소 → SellerWalletNotFoundException", async () => {
-    ctx.userModel.findOne.mockReturnValue(makeQueryChain(null));
-
-    await expect(ctx.service.create(dto, BUYER_ID.toString())).rejects.toThrow(
-      SellerWalletNotFoundException,
-    );
-  });
-
-  it("buyer가 아닌 제3자 → UnauthorizedPaymentActionException", async () => {
     await expect(
-      ctx.service.create(dto, "000000000000000000000000"),
+      ctx.service.create(
+        { counterpartyWalletAddress: SELLER_WALLET_ADDRESS, escrows },
+        "000000000000000000000000",
+      ),
     ).rejects.toThrow(UnauthorizedPaymentActionException);
   });
 });

--- a/src/modules/escrow-payments/dto/create-escrow-payment.dto.ts
+++ b/src/modules/escrow-payments/dto/create-escrow-payment.dto.ts
@@ -5,7 +5,6 @@ import {
   ArrayMinSize,
   IsEnum,
   IsInt,
-  IsMongoId,
   IsNumber,
   IsOptional,
   IsPositive,
@@ -42,21 +41,15 @@ export class EscrowItemDto {
 
 export class CreateEscrowPaymentDto {
   @ApiProperty({
-    description: "구매자 User ID (MongoDB ObjectId)",
-    example: "665f1a2b3c4d5e6f7a8b9c0d",
-  })
-  @IsMongoId()
-  buyerId: string;
-
-  @ApiProperty({
-    description: "판매자 XRPL 지갑 주소",
+    description:
+      "상대방(거래 상대) XRPL 지갑 주소. buyer가 생성하면 seller 주소, seller가 생성하면 buyer 주소.",
     example: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
   })
   @IsString()
   @Matches(/^r[1-9A-HJ-NP-Za-km-z]{24,34}$/, {
-    message: "sellerWalletAddress must be a valid XRPL address",
+    message: "counterpartyWalletAddress must be a valid XRPL address",
   })
-  sellerWalletAddress: string;
+  counterpartyWalletAddress: string;
 
   @ApiProperty({
     description: "결제 메모",

--- a/src/modules/escrow-payments/escrow-payments-crud.service.ts
+++ b/src/modules/escrow-payments/escrow-payments-crud.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
 import { Model, Types } from "mongoose";
 import {
+  BuyerWalletNotFoundException,
   EscrowPaymentNotFoundException,
   SellerWalletNotFoundException,
   UnauthorizedPaymentActionException,
@@ -27,29 +28,59 @@ export class EscrowPaymentsCrudService {
     dto: CreateEscrowPaymentDto,
     userId: string,
   ): Promise<EscrowPaymentDocument> {
-    if (userId !== dto.buyerId) {
+    const creator = await this.userModel.findById(userId, { type: 1 }).lean();
+    if (!creator) throw new UnauthorizedPaymentActionException();
+
+    const now = new Date();
+    let buyerId: string;
+    let sellerId: string;
+    let buyerApproved = false;
+    let buyerApprovedAt: Date | undefined;
+    let sellerApproved = false;
+    let sellerApprovedAt: Date | undefined;
+
+    if (creator.type === "buyer") {
+      const seller = await this.userModel
+        .findOne(
+          { "wallet.address": dto.counterpartyWalletAddress, type: "seller" },
+          { _id: 1 },
+        )
+        .lean();
+      if (!seller)
+        throw new SellerWalletNotFoundException(dto.counterpartyWalletAddress);
+
+      buyerId = userId;
+      sellerId = seller._id.toString();
+      buyerApproved = true;
+      buyerApprovedAt = now;
+    } else if (creator.type === "seller") {
+      const buyer = await this.userModel
+        .findOne(
+          { "wallet.address": dto.counterpartyWalletAddress, type: "buyer" },
+          { _id: 1 },
+        )
+        .lean();
+      if (!buyer)
+        throw new BuyerWalletNotFoundException(dto.counterpartyWalletAddress);
+
+      buyerId = buyer._id.toString();
+      sellerId = userId;
+      sellerApproved = true;
+      sellerApprovedAt = now;
+    } else {
       throw new UnauthorizedPaymentActionException();
     }
 
-    const seller = await this.userModel
-      .findOne(
-        { "wallet.address": dto.sellerWalletAddress, type: "seller" },
-        { _id: 1 },
-      )
-      .lean();
-    if (!seller)
-      throw new SellerWalletNotFoundException(dto.sellerWalletAddress);
-
-    const sellerId = seller._id.toString();
     const totalAmountXrp = dto.escrows.reduce((sum, e) => sum + e.amountXrp, 0);
 
-    const now = new Date();
     const doc = new this.escrowPaymentModel({
-      buyerId: new Types.ObjectId(dto.buyerId),
+      buyerId: new Types.ObjectId(buyerId),
       sellerId: new Types.ObjectId(sellerId),
       totalAmountXrp,
-      buyerApproved: true,
-      buyerApprovedAt: now,
+      buyerApproved,
+      buyerApprovedAt,
+      sellerApproved,
+      sellerApprovedAt,
       currency: dto.currency ?? "XRP",
       memo: dto.memo ?? "",
       escrows: dto.escrows.map((e) => ({

--- a/src/modules/escrow-payments/escrow-payments.service.ts
+++ b/src/modules/escrow-payments/escrow-payments.service.ts
@@ -39,7 +39,9 @@ export class EscrowPaymentsService {
   ) {}
 
   /**
-   * 결제 승인 메서드 (buyer가 생성한 결제 내역을 seller가 승인하는 절차)
+   * 결제 승인 메서드 — 결제 생성자(buyer/seller)의 상대방이 호출해 APPROVED로 전환
+   * buyer 생성 시: seller가 호출 → APPROVED
+   * seller 생성 시: buyer가 호출 → APPROVED
    */
   async approvePayment(
     paymentId: string,

--- a/test/escrow-mock.e2e-spec.ts
+++ b/test/escrow-mock.e2e-spec.ts
@@ -395,7 +395,9 @@ describe("EscrowPayments (e2e)", () => {
       await request(app.getHttpServer())
         .post("/escrow-payments")
         .set(asBuyer())
-        .send(baseCreatePayload({ counterpartyWalletAddress: "invalid-address" }))
+        .send(
+          baseCreatePayload({ counterpartyWalletAddress: "invalid-address" }),
+        )
         .expect(400);
     });
 

--- a/test/escrow-mock.e2e-spec.ts
+++ b/test/escrow-mock.e2e-spec.ts
@@ -258,10 +258,9 @@ describe("EscrowPayments (e2e)", () => {
     );
   }
 
-  // 기본 생성 payload 헬퍼
+  // 기본 생성 payload 헬퍼 (buyer가 생성 — counterpartyWalletAddress = seller 주소)
   const baseCreatePayload = (overrides: object = {}) => ({
-    buyerId: buyerObjectId.toString(),
-    sellerWalletAddress: SELLER_WALLET_ADDR,
+    counterpartyWalletAddress: SELLER_WALLET_ADDR,
     memo: "테스트 메모",
     escrows: [
       {
@@ -392,11 +391,11 @@ describe("EscrowPayments (e2e)", () => {
       expect(second.amountXrp).toBe(700);
     });
 
-    it("buyerId가 유효하지 않은 MongoId → 400", async () => {
+    it("counterpartyWalletAddress가 유효하지 않은 XRPL 주소 → 400", async () => {
       await request(app.getHttpServer())
         .post("/escrow-payments")
         .set(asBuyer())
-        .send(baseCreatePayload({ buyerId: "invalid-id" }))
+        .send(baseCreatePayload({ counterpartyWalletAddress: "invalid-address" }))
         .expect(400);
     });
 
@@ -577,6 +576,63 @@ describe("EscrowPayments (e2e)", () => {
 
       await request(app.getHttpServer())
         .post(`/escrow-payments/${paymentId}/approve`)
+        .set(asSeller())
+        .expect(400);
+    });
+
+    it("seller가 생성한 결제 → buyer 승인 → APPROVED", async () => {
+      const createRes = await request(app.getHttpServer())
+        .post("/escrow-payments")
+        .set(asSeller())
+        .send({
+          counterpartyWalletAddress: BUYER_WALLET_ADDR,
+          memo: "seller 생성 테스트",
+          escrows: [
+            {
+              label: "초기금",
+              amountXrp: 300,
+              order: 0,
+              requiredEventTypes: ["SHIPMENT_CONFIRMED"],
+            },
+          ],
+        })
+        .expect(201);
+
+      const sellerCreatedId = createRes.body._id;
+      expect(createRes.body.sellerApproved).toBe(true);
+      expect(createRes.body.sellerApprovedAt).toBeDefined();
+      expect(createRes.body.buyerApproved).toBe(false);
+
+      const approveRes = await request(app.getHttpServer())
+        .post(`/escrow-payments/${sellerCreatedId}/approve`)
+        .set(asBuyer())
+        .expect(201);
+
+      expect(approveRes.body.status).toBe("APPROVED");
+      expect(approveRes.body.buyerApproved).toBe(true);
+      expect(approveRes.body.sellerApproved).toBe(true);
+    });
+
+    it("seller가 생성한 결제 → seller 중복 승인 → 400", async () => {
+      const createRes = await request(app.getHttpServer())
+        .post("/escrow-payments")
+        .set(asSeller())
+        .send({
+          counterpartyWalletAddress: BUYER_WALLET_ADDR,
+          memo: "seller 중복 승인 테스트",
+          escrows: [
+            {
+              label: "초기금",
+              amountXrp: 100,
+              order: 0,
+              requiredEventTypes: ["SHIPMENT_CONFIRMED"],
+            },
+          ],
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post(`/escrow-payments/${createRes.body._id}/approve`)
         .set(asSeller())
         .expect(400);
     });

--- a/test/escrow-rlusd-mock.e2e-spec.ts
+++ b/test/escrow-rlusd-mock.e2e-spec.ts
@@ -228,8 +228,7 @@ describe("RLUSD 에스크로 결제 (mock e2e)", () => {
   }
 
   const rlusdCreatePayload = (overrides: object = {}) => ({
-    buyerId: buyerObjectId.toString(),
-    sellerWalletAddress: SELLER_ADDRESS,
+    counterpartyWalletAddress: SELLER_ADDRESS,
     memo: "RLUSD 테스트 결제",
     currency: "RLUSD",
     escrows: [
@@ -286,8 +285,7 @@ describe("RLUSD 에스크로 결제 (mock e2e)", () => {
         .post("/escrow-payments")
         .set(asBuyer())
         .send({
-          buyerId: buyerObjectId.toString(),
-          sellerWalletAddress: SELLER_ADDRESS,
+          counterpartyWalletAddress: SELLER_ADDRESS,
           escrows: [
             {
               label: "초기금",

--- a/test/escrow-rlusd-testnet.e2e-spec.ts
+++ b/test/escrow-rlusd-testnet.e2e-spec.ts
@@ -247,8 +247,7 @@ describe("RLUSD 에스크로 결제 테스트넷 통합 테스트", () => {
     // ── 1. 결제 생성 ─────────────────────────────────────────────────────
     const payment = await crudService.create(
       {
-        buyerId: buyerObjectId.toString(),
-        sellerWalletAddress: sellerWalletAddress,
+        counterpartyWalletAddress: sellerWalletAddress,
         memo: "테스트넷 TST 토큰 에스크로",
         currency: "RLUSD", // 서비스 분기 기준: RLUSD 코드 경로 사용
         escrows: [

--- a/test/escrow-testnet.e2e-spec.ts
+++ b/test/escrow-testnet.e2e-spec.ts
@@ -192,8 +192,7 @@ describe("XRPL Escrow Testnet (풀스택 통합 테스트)", () => {
     // ── 1. 결제 내역 생성 ─────────────────────────────────────────────────
     const payment = await crudService.create(
       {
-        buyerId: buyerObjectId.toString(),
-        sellerWalletAddress: sellerWalletAddress,
+        counterpartyWalletAddress: sellerWalletAddress,
         memo: "테스트넷 초기금 에스크로",
         escrows: [
           {


### PR DESCRIPTION
## 변경 사항

### 에스크로 결제 — 양방향 생성/승인
- **생성자 자동 승인**: 결제 내역 생성 시 생성자(buyer/seller)의 승인 플래그를 자동으로 `true`로 설정
- **양방향 생성**: buyer뿐 아니라 seller도 결제 내역을 생성할 수 있도록 변경
  - DTO: `buyerId` + `sellerWalletAddress` → `counterpartyWalletAddress` 단일 필드로 통합
  - 생성자의 role을 세션 userId로 DB 조회해 자동 판별, 상대방은 지갑 주소로 탐색
- **양방향 승인**: buyer가 생성하면 seller가 승인, seller가 생성하면 buyer가 승인 → 즉시 APPROVED


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 판매자가 생성한 결제에 대한 지원 추가
  * 결제 생성 시 상대방 지갑 주소를 통한 더 간편한 상대방 식별

* **개선 사항**
  * 구매자 및 판매자의 결제 승인 흐름 최적화
  * 지갑 검색 실패에 대한 명확한 오류 처리 강화
  * 승인 프로세스 설명 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/K-Statra/backend/pull/29)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->