### PR TITLE
[FEAT] 결제내역 생성 시 buyer, seller 회사 이름 컬럼 추가

### DIFF
--- a/src/modules/escrow-payments/__tests__/create.spec.ts
+++ b/src/modules/escrow-payments/__tests__/create.spec.ts
@@ -42,8 +42,12 @@ describe("EscrowPaymentsCrudService › create", () => {
 
     beforeEach(async () => {
       ctx = await makeCrudServiceTestingModule();
-      ctx.userModel.findById.mockReturnValue(makeQueryChain({ type: "buyer" }));
-      ctx.userModel.findOne.mockReturnValue(makeQueryChain({ _id: SELLER_ID }));
+      ctx.userModel.findById.mockReturnValue(
+        makeQueryChain({ type: "buyer", name: "Buyer Corp" }),
+      );
+      ctx.userModel.findOne.mockReturnValue(
+        makeQueryChain({ _id: SELLER_ID, name: "Seller Corp" }),
+      );
     });
 
     it("totalAmountXrp를 escrow 항목 합산으로 계산", async () => {
@@ -90,7 +94,7 @@ describe("EscrowPaymentsCrudService › create", () => {
 
       expect(ctx.userModel.findOne).toHaveBeenCalledWith(
         { "wallet.address": SELLER_WALLET_ADDRESS, type: "seller" },
-        { _id: 1 },
+        { _id: 1, name: 1 },
       );
 
       const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
@@ -118,9 +122,11 @@ describe("EscrowPaymentsCrudService › create", () => {
     beforeEach(async () => {
       ctx = await makeCrudServiceTestingModule();
       ctx.userModel.findById.mockReturnValue(
-        makeQueryChain({ type: "seller" }),
+        makeQueryChain({ type: "seller", name: "Seller Corp" }),
       );
-      ctx.userModel.findOne.mockReturnValue(makeQueryChain({ _id: BUYER_ID }));
+      ctx.userModel.findOne.mockReturnValue(
+        makeQueryChain({ _id: BUYER_ID, name: "Buyer Corp" }),
+      );
     });
 
     it("생성자(seller)의 sellerApproved를 true로 자동 설정", async () => {
@@ -137,7 +143,7 @@ describe("EscrowPaymentsCrudService › create", () => {
 
       expect(ctx.userModel.findOne).toHaveBeenCalledWith(
         { "wallet.address": BUYER_WALLET_ADDRESS, type: "buyer" },
-        { _id: 1 },
+        { _id: 1, name: 1 },
       );
 
       const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];

--- a/src/modules/escrow-payments/__tests__/helpers.ts
+++ b/src/modules/escrow-payments/__tests__/helpers.ts
@@ -79,7 +79,9 @@ export function makePayment(overrides: object = {}) {
   const doc: any = {
     _id: PAYMENT_ID,
     buyerId: BUYER_ID,
+    buyerName: "Default Buyer Corp",
     sellerId: SELLER_ID,
+    sellerName: "Default Seller Corp",
     totalAmountXrp: 300,
     status: "DRAFT",
     memo: "",

--- a/src/modules/escrow-payments/escrow-payments-crud.service.ts
+++ b/src/modules/escrow-payments/escrow-payments-crud.service.ts
@@ -15,6 +15,18 @@ import { User, UserDocument } from "../users/schemas/user.schema";
 import { CreateEscrowPaymentDto } from "./dto/create-escrow-payment.dto";
 import { QueryEscrowPaymentDto } from "./dto/query-escrow-payment.dto";
 
+export interface EscrowPaymentWithPartner extends Omit<
+  EscrowPayment,
+  "buyerId" | "sellerId"
+> {
+  _id: Types.ObjectId;
+  buyerId: Types.ObjectId;
+  sellerId: Types.ObjectId;
+  partnerName: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 @Injectable()
 export class EscrowPaymentsCrudService {
   constructor(
@@ -113,7 +125,7 @@ export class EscrowPaymentsCrudService {
     userId: string,
     dto: QueryEscrowPaymentDto,
   ): Promise<{
-    data: any[];
+    data: EscrowPaymentWithPartner[];
     total: number;
     page: number;
     limit: number;

--- a/src/modules/escrow-payments/escrow-payments-crud.service.ts
+++ b/src/modules/escrow-payments/escrow-payments-crud.service.ts
@@ -28,12 +28,16 @@ export class EscrowPaymentsCrudService {
     dto: CreateEscrowPaymentDto,
     userId: string,
   ): Promise<EscrowPaymentDocument> {
-    const creator = await this.userModel.findById(userId, { type: 1 }).lean();
+    const creator = await this.userModel
+      .findById(userId, { type: 1, name: 1 })
+      .lean();
     if (!creator) throw new UnauthorizedPaymentActionException();
 
     const now = new Date();
     let buyerId: string;
+    let buyerName: string;
     let sellerId: string;
+    let sellerName: string;
     let buyerApproved = false;
     let buyerApprovedAt: Date | undefined;
     let sellerApproved = false;
@@ -43,28 +47,32 @@ export class EscrowPaymentsCrudService {
       const seller = await this.userModel
         .findOne(
           { "wallet.address": dto.counterpartyWalletAddress, type: "seller" },
-          { _id: 1 },
+          { _id: 1, name: 1 },
         )
         .lean();
       if (!seller)
         throw new SellerWalletNotFoundException(dto.counterpartyWalletAddress);
 
       buyerId = userId;
+      buyerName = creator.name;
       sellerId = seller._id.toString();
+      sellerName = seller.name;
       buyerApproved = true;
       buyerApprovedAt = now;
     } else if (creator.type === "seller") {
       const buyer = await this.userModel
         .findOne(
           { "wallet.address": dto.counterpartyWalletAddress, type: "buyer" },
-          { _id: 1 },
+          { _id: 1, name: 1 },
         )
         .lean();
       if (!buyer)
         throw new BuyerWalletNotFoundException(dto.counterpartyWalletAddress);
 
       buyerId = buyer._id.toString();
+      buyerName = buyer.name;
       sellerId = userId;
+      sellerName = creator.name;
       sellerApproved = true;
       sellerApprovedAt = now;
     } else {
@@ -75,7 +83,9 @@ export class EscrowPaymentsCrudService {
 
     const doc = new this.escrowPaymentModel({
       buyerId: new Types.ObjectId(buyerId),
+      buyerName,
       sellerId: new Types.ObjectId(sellerId),
+      sellerName,
       totalAmountXrp,
       buyerApproved,
       buyerApprovedAt,
@@ -103,7 +113,7 @@ export class EscrowPaymentsCrudService {
     userId: string,
     dto: QueryEscrowPaymentDto,
   ): Promise<{
-    data: EscrowPaymentDocument[];
+    data: any[];
     total: number;
     page: number;
     limit: number;
@@ -136,8 +146,17 @@ export class EscrowPaymentsCrudService {
       this.escrowPaymentModel.countDocuments(filter),
     ]);
 
+    const mappedData = data.map((item: any) => {
+      const isBuyer = item.buyerId.toString() === userId;
+      const partnerName = isBuyer ? item.sellerName : item.buyerName;
+      return {
+        ...item,
+        partnerName,
+      };
+    });
+
     return {
-      data: data as unknown as EscrowPaymentDocument[],
+      data: mappedData,
       total,
       page,
       limit,

--- a/src/modules/escrow-payments/schemas/escrow-payment.schema.ts
+++ b/src/modules/escrow-payments/schemas/escrow-payment.schema.ts
@@ -77,8 +77,14 @@ export class EscrowPayment {
   @Prop({ type: Types.ObjectId, ref: "User", required: true, index: true })
   buyerId: Types.ObjectId;
 
+  @Prop({ required: true })
+  buyerName: string;
+
   @Prop({ type: Types.ObjectId, ref: "User", required: true, index: true })
   sellerId: Types.ObjectId;
+
+  @Prop({ required: true })
+  sellerName: string;
 
   @Prop({ required: true, min: 0 }) totalAmountXrp: number;
 


### PR DESCRIPTION
Resolves #32 

## 개요

결제 내역 생성 시 상대 회사 이름을 보여주도록 컬럼 추가

## 구현

- 반정규화 이용하여 JOIN 없이 결제내역 컬럼에 `buyerName`, `sellerName` 추가

## 테스트

- 결제내역 생성 시 buyerName, sellerName 추가하여 수정함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 에스크로 결제 기록에 구매자 및 판매자의 이름이 저장되고 관리됩니다.

## 개선 사항
* 에스크로 결제 목록을 조회할 때 거래 파트너의 이름 정보가 함께 반환되어 거래 대상 확인이 더욱 편리해졌습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/K-Statra/backend/pull/34)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->