### PR TITLE
[FEAT] 에스크로 결제 내역의 DRAFT 상태 제거 및 초기 상태를 PENDING_APPROVAL로 변경

### DIFF
--- a/src/modules/escrow-payments/__tests__/approval.spec.ts
+++ b/src/modules/escrow-payments/__tests__/approval.spec.ts
@@ -40,7 +40,7 @@ describe("EscrowPaymentsService › approvePayment", () => {
   describe("buyer가 생성한 결제", () => {
     it("seller 승인 → APPROVED, sellerApproved=true", async () => {
       const payment = makePayment({
-        status: "DRAFT",
+        status: "PENDING_APPROVAL",
         buyerApproved: true,
         buyerApprovedAt: new Date(),
       });
@@ -58,7 +58,10 @@ describe("EscrowPaymentsService › approvePayment", () => {
     });
 
     it("buyer 중복 승인 → AlreadyApprovedPaymentException, save 미호출", async () => {
-      const payment = makePayment({ status: "DRAFT", buyerApproved: true });
+      const payment = makePayment({
+        status: "PENDING_APPROVAL",
+        buyerApproved: true,
+      });
       ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
 
       await expect(
@@ -73,7 +76,7 @@ describe("EscrowPaymentsService › approvePayment", () => {
   describe("seller가 생성한 결제", () => {
     it("buyer 승인 → APPROVED, buyerApproved=true", async () => {
       const payment = makePayment({
-        status: "DRAFT",
+        status: "PENDING_APPROVAL",
         sellerApproved: true,
         sellerApprovedAt: new Date(),
       });
@@ -91,7 +94,10 @@ describe("EscrowPaymentsService › approvePayment", () => {
     });
 
     it("seller 중복 승인 → AlreadyApprovedPaymentException, save 미호출", async () => {
-      const payment = makePayment({ status: "DRAFT", sellerApproved: true });
+      const payment = makePayment({
+        status: "PENDING_APPROVAL",
+        sellerApproved: true,
+      });
       ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
 
       await expect(
@@ -113,7 +119,7 @@ describe("EscrowPaymentsService › approvePayment", () => {
   });
 
   it("buyer도 seller도 아닌 제3자 → UnauthorizedPaymentActionException", async () => {
-    const payment = makePayment({ status: "DRAFT" });
+    const payment = makePayment({ status: "PENDING_APPROVAL" });
     ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
 
     await expect(

--- a/src/modules/escrow-payments/__tests__/create.spec.ts
+++ b/src/modules/escrow-payments/__tests__/create.spec.ts
@@ -80,6 +80,13 @@ describe("EscrowPaymentsCrudService › create", () => {
       expect(constructorArg.sellerApproved).toBe(false);
     });
 
+    it("상태를 PENDING_APPROVAL로 초기화", async () => {
+      await ctx.service.create(makeDto(), BUYER_ID.toString());
+
+      const constructorArg = ctx.escrowPaymentModel.mock.calls[0][0];
+      expect(constructorArg.status).toBe("PENDING_APPROVAL");
+    });
+
     it("save() 호출", async () => {
       const instance = { save: jest.fn().mockResolvedValue({}) };
       ctx.escrowPaymentModel.mockReturnValue(instance);

--- a/src/modules/escrow-payments/__tests__/helpers.ts
+++ b/src/modules/escrow-payments/__tests__/helpers.ts
@@ -83,7 +83,7 @@ export function makePayment(overrides: object = {}) {
     sellerId: SELLER_ID,
     sellerName: "Default Seller Corp",
     totalAmountXrp: 300,
-    status: "DRAFT",
+    status: "PENDING_APPROVAL",
     memo: "",
     buyerApproved: false,
     buyerApprovedAt: undefined,

--- a/src/modules/escrow-payments/__tests__/initiate.spec.ts
+++ b/src/modules/escrow-payments/__tests__/initiate.spec.ts
@@ -56,7 +56,10 @@ describe("EscrowPaymentsService › initiatePayment", () => {
   });
 
   it("APPROVED 아닌 상태 → PaymentNotApprovedForPayException", async () => {
-    const payment = makePayment({ status: "DRAFT", buyerId: BUYER_ID });
+    const payment = makePayment({
+      status: "PENDING_APPROVAL",
+      buyerId: BUYER_ID,
+    });
     ctx.escrowPaymentModel.findById.mockReturnValue(makeQueryChain(payment));
 
     await expect(

--- a/src/modules/escrow-payments/__tests__/query.spec.ts
+++ b/src/modules/escrow-payments/__tests__/query.spec.ts
@@ -34,7 +34,7 @@ describe("EscrowPaymentsCrudService › findAll", () => {
     );
   });
 
-  it("group=ongoing → DRAFT/PENDING_APPROVAL/APPROVED/PROCESSING/ACTIVE 필터", async () => {
+  it("group=ongoing → PENDING_APPROVAL/APPROVED/PROCESSING/ACTIVE 필터", async () => {
     await ctx.service.findAll(BUYER_ID.toString(), {
       group: "ongoing",
       page: 1,
@@ -44,7 +44,6 @@ describe("EscrowPaymentsCrudService › findAll", () => {
     const filter = ctx.escrowPaymentModel.find.mock.calls[0][0];
     expect(filter.status.$in).toEqual(
       expect.arrayContaining([
-        "DRAFT",
         "PENDING_APPROVAL",
         "APPROVED",
         "PROCESSING",

--- a/src/modules/escrow-payments/dto/query-escrow-payment.dto.ts
+++ b/src/modules/escrow-payments/dto/query-escrow-payment.dto.ts
@@ -7,7 +7,6 @@ export class QueryEscrowPaymentDto {
   @ApiPropertyOptional({
     description: "상태 필터",
     enum: [
-      "DRAFT",
       "PENDING_APPROVAL",
       "APPROVED",
       "PROCESSING",
@@ -18,7 +17,6 @@ export class QueryEscrowPaymentDto {
   })
   @IsOptional()
   @IsEnum([
-    "DRAFT",
     "PENDING_APPROVAL",
     "APPROVED",
     "PROCESSING",

--- a/src/modules/escrow-payments/escrow-payments-crud.service.ts
+++ b/src/modules/escrow-payments/escrow-payments-crud.service.ts
@@ -103,6 +103,7 @@ export class EscrowPaymentsCrudService {
       buyerApprovedAt,
       sellerApproved,
       sellerApprovedAt,
+      status: "PENDING_APPROVAL",
       currency: dto.currency ?? "XRP",
       memo: dto.memo ?? "",
       escrows: dto.escrows.map((e) => ({
@@ -141,7 +142,7 @@ export class EscrowPaymentsCrudService {
       filter.status = status;
     } else if (group === "ongoing") {
       filter.status = {
-        $in: ["DRAFT", "PENDING_APPROVAL", "APPROVED", "PROCESSING", "ACTIVE"],
+        $in: ["PENDING_APPROVAL", "APPROVED", "PROCESSING", "ACTIVE"],
       };
     } else if (group === "done") {
       filter.status = { $in: ["COMPLETED", "CANCELLED"] };

--- a/src/modules/escrow-payments/escrow-payments.controller.ts
+++ b/src/modules/escrow-payments/escrow-payments.controller.ts
@@ -57,7 +57,7 @@ export class EscrowPaymentsController {
     summary: "내 에스크로 결제 목록 조회",
     description:
       "로그인한 유저가 buyer 또는 seller로 참여한 에스크로 결제 내역을 최신순으로 반환합니다. " +
-      "group=ongoing이면 진행중(DRAFT/PENDING_APPROVAL/ACTIVE), group=done이면 종료(COMPLETED/CANCELLED) 필터링.",
+      "group=ongoing이면 진행중(PENDING_APPROVAL/APPROVED/PROCESSING/ACTIVE), group=done이면 종료(COMPLETED/CANCELLED) 필터링.",
   })
   @ApiResponse({
     status: 200,
@@ -75,7 +75,7 @@ export class EscrowPaymentsController {
   @ApiOperation({
     summary: "에스크로 결제 내역 생성",
     description:
-      "buyer/seller 간 에스크로 결제 계획을 생성합니다. 생성 직후 상태는 DRAFT이며, 양측이 모두 승인해야 ACTIVE로 전환됩니다.",
+      "buyer/seller 간 에스크로 결제 계획을 생성합니다. 생성 직후 상태는 PENDING_APPROVAL이며, 양측이 모두 승인해야 APPROVED로 전환됩니다.",
   })
   @ApiBody({ type: CreateEscrowPaymentDto })
   @ApiResponse({ status: 201, description: "결제 내역 생성 성공" })
@@ -109,14 +109,15 @@ export class EscrowPaymentsController {
     summary: "결제 계획 승인",
     description:
       "세션 유저(buyer 또는 seller)가 결제 계획을 승인합니다. " +
-      "한 쪽만 승인하면 PENDING_APPROVAL, 양측 모두 승인하면 ACTIVE로 전환됩니다. " +
-      "ACTIVE 상태여야 XRPL 에스크로 실행이 가능합니다.",
+      "한 쪽만 승인하면 PENDING_APPROVAL, 양측 모두 승인하면 APPROVED로 전환됩니다. " +
+      "APPROVED 상태여야 XRPL 에스크로 실행이 가능합니다.",
   })
   @ApiParam({ name: "id", description: "에스크로 결제 ID (MongoDB ObjectId)" })
   @ApiResponse({ status: 201, description: "승인 처리 성공" })
   @ApiResponse({
     status: 400,
-    description: "이미 승인됐거나 승인 불가 상태 (ACTIVE/COMPLETED/CANCELLED)",
+    description:
+      "이미 승인됐거나 승인 불가 상태 (APPROVED/PROCESSING/ACTIVE/COMPLETED/CANCELLED)",
   })
   @ApiResponse({ status: 404, description: "결제 내역 없음" })
   approvePayment(

--- a/src/modules/escrow-payments/escrow-payments.service.ts
+++ b/src/modules/escrow-payments/escrow-payments.service.ts
@@ -54,7 +54,7 @@ export class EscrowPaymentsService {
     const isSeller = payment.sellerId.toString() === userId;
     if (!isBuyer && !isSeller) throw new UnauthorizedPaymentActionException();
 
-    if (payment.status !== "DRAFT" && payment.status !== "PENDING_APPROVAL") {
+    if (payment.status !== "PENDING_APPROVAL") {
       throw new InvalidPaymentStatusException(payment.status);
     }
 

--- a/src/modules/escrow-payments/schemas/escrow-payment.schema.ts
+++ b/src/modules/escrow-payments/schemas/escrow-payment.schema.ts
@@ -3,7 +3,6 @@ import { Document, Types } from "mongoose";
 
 export type EscrowPaymentDocument = EscrowPayment & Document;
 export type EscrowPaymentStatus =
-  | "DRAFT"
   | "PENDING_APPROVAL"
   | "APPROVED"
   | "PROCESSING"
@@ -94,7 +93,6 @@ export class EscrowPayment {
   @Prop({
     type: String,
     enum: [
-      "DRAFT",
       "PENDING_APPROVAL",
       "APPROVED",
       "PROCESSING",
@@ -102,7 +100,7 @@ export class EscrowPayment {
       "COMPLETED",
       "CANCELLED",
     ],
-    default: "DRAFT",
+    default: "PENDING_APPROVAL",
     index: true,
   })
   status: EscrowPaymentStatus;

--- a/test/escrow-mock.e2e-spec.ts
+++ b/test/escrow-mock.e2e-spec.ts
@@ -338,7 +338,7 @@ describe("EscrowPayments (e2e)", () => {
   // ── POST /escrow-payments ─────────────────────────────────────────────────
 
   describe("POST /escrow-payments", () => {
-    it("정상 데이터 → 201, DRAFT 상태로 생성", async () => {
+    it("정상 데이터 → 201, PENDING_APPROVAL 상태로 생성", async () => {
       const res = await request(app.getHttpServer())
         .post("/escrow-payments")
         .set(asBuyer())
@@ -346,7 +346,7 @@ describe("EscrowPayments (e2e)", () => {
         .expect(201);
 
       expect(res.body._id).toBeDefined();
-      expect(res.body.status).toBe("DRAFT");
+      expect(res.body.status).toBe("PENDING_APPROVAL");
       expect(res.body.totalAmountXrp).toBe(500);
       expect(res.body.buyerApproved).toBe(true);
       expect(res.body.buyerApprovedAt).toBeDefined();
@@ -448,7 +448,7 @@ describe("EscrowPayments (e2e)", () => {
       });
     });
 
-    it("group=ongoing → DRAFT/PENDING_APPROVAL/APPROVED/PROCESSING/ACTIVE 만 포함", async () => {
+    it("group=ongoing → PENDING_APPROVAL/APPROVED/PROCESSING/ACTIVE 만 포함", async () => {
       const res = await request(app.getHttpServer())
         .get("/escrow-payments?group=ongoing")
         .set(asBuyer())
@@ -456,7 +456,6 @@ describe("EscrowPayments (e2e)", () => {
 
       for (const p of res.body.data) {
         expect([
-          "DRAFT",
           "PENDING_APPROVAL",
           "APPROVED",
           "PROCESSING",
@@ -735,15 +734,15 @@ describe("EscrowPayments (e2e)", () => {
         .expect(403);
     });
 
-    it("APPROVED 아닌 결제(DRAFT) → 400", async () => {
-      const draftRes = await request(app.getHttpServer())
+    it("APPROVED 아닌 결제(PENDING_APPROVAL) → 400", async () => {
+      const pendingRes = await request(app.getHttpServer())
         .post("/escrow-payments")
         .set(asBuyer())
         .send(baseCreatePayload());
-      const draftId = draftRes.body._id;
+      const pendingId = pendingRes.body._id;
 
       await request(app.getHttpServer())
-        .post(`/escrow-payments/${draftId}/pay`)
+        .post(`/escrow-payments/${pendingId}/pay`)
         .set(asBuyer())
         .expect(400);
     });

--- a/test/escrow-rlusd-mock.e2e-spec.ts
+++ b/test/escrow-rlusd-mock.e2e-spec.ts
@@ -277,7 +277,7 @@ describe("RLUSD 에스크로 결제 (mock e2e)", () => {
         .expect(201);
 
       expect(res.body.currency).toBe("RLUSD");
-      expect(res.body.status).toBe("DRAFT");
+      expect(res.body.status).toBe("PENDING_APPROVAL");
     });
 
     it("currency 미전달 → XRP 기본값", async () => {

--- a/test/escrow-rlusd-testnet.e2e-spec.ts
+++ b/test/escrow-rlusd-testnet.e2e-spec.ts
@@ -265,7 +265,7 @@ describe("RLUSD 에스크로 결제 테스트넷 통합 테스트", () => {
     const paymentId = payment._id.toString();
     const escrowItemId = payment.escrows[0]._id.toString();
 
-    expect(payment.status).toBe("DRAFT");
+    expect(payment.status).toBe("PENDING_APPROVAL");
     expect(payment.buyerApproved).toBe(true);
     expect(payment.buyerApprovedAt).toBeDefined();
     expect(payment.currency).toBe("RLUSD");

--- a/test/escrow-testnet.e2e-spec.ts
+++ b/test/escrow-testnet.e2e-spec.ts
@@ -209,7 +209,7 @@ describe("XRPL Escrow Testnet (풀스택 통합 테스트)", () => {
     const paymentId = payment._id.toString();
     const escrowItemId = payment.escrows[0]._id.toString();
 
-    expect(payment.status).toBe("DRAFT");
+    expect(payment.status).toBe("PENDING_APPROVAL");
     expect(payment.buyerApproved).toBe(true);
     expect(payment.buyerApprovedAt).toBeDefined();
     expect(payment.totalAmountXrp).toBe(10);


### PR DESCRIPTION
Resolves #35 

## 개요 

- 에스크로 결제 내역의 DRAFT 상태 제거 및 초기 상태를 PENDING_APPROVAL로 변경

## 테스트

- DRAFT 삭제 및 첫 생성 시 PENDING_APPROVAL 검증 추가 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경 사항**
  * 에스크로 결제의 초기 상태가 "PENDING_APPROVAL"로 변경되었습니다. (기존: "DRAFT")
  * 결제 승인 워크플로우가 업데이트되어 "PENDING_APPROVAL" 상태에서만 승인이 가능합니다.
  * 진행 중인 결제 목록 조회 시 포함되는 상태 목록이 조정되었습니다.

* **테스트**
  * 에스크로 결제 관련 테스트가 새로운 상태 정책에 맞게 업데이트되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/K-Statra/backend/pull/36)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->