### PR TITLE
[HOTFIX] 개인 정보 조회 시 seed 유출 막음

### DIFF
--- a/src/modules/my-business/my-business.service.spec.ts
+++ b/src/modules/my-business/my-business.service.spec.ts
@@ -91,6 +91,23 @@ describe("MyBusinessService", () => {
         NotFoundException,
       );
     });
+
+    it("프로필 조회 시 민감한 정보(wallet.seed)가 포함되지 않음", async () => {
+      const mockUser = {
+        _id: USER_ID,
+        wallet: { address: "rXXXXX", publicKey: "edXXXXX" },
+      };
+      userModel.findById.mockReturnValue(buildFindMock(mockUser));
+
+      await service.getProfile(USER_ID);
+
+      // findById 호출 시 전달된 프로젝션 확인
+      const projection = userModel.findById.mock.calls[0][1];
+      expect(projection).not.toHaveProperty("wallet");
+      expect(projection).toHaveProperty(["wallet.address"], 1);
+      expect(projection).toHaveProperty(["wallet.publicKey"], 1);
+      expect(projection).not.toHaveProperty(["wallet.seed"]);
+    });
   });
 
   // ── savePartner ───────────────────────────────────────────────────────────────

--- a/src/modules/my-business/my-business.service.ts
+++ b/src/modules/my-business/my-business.service.ts
@@ -27,7 +27,8 @@ export class MyBusinessService {
     contactName: 1,
     phone: 1,
     industries: 1,
-    wallet: 1,
+    "wallet.address": 1,
+    "wallet.publicKey": 1,
     status: 1,
     type: 1,
     // seller


### PR DESCRIPTION
## 개요

My-business의 개인정보 조회 시 seed키도 같이 유출됨

## 해결

```
"wallet.address": 1,
"wallet.publicKey": 1,
```

기존 PROJECTION에 "wallet" : 1 로 설정되며 seed도 같이 유출됨.

위 코드처럼 수정함.

## 테스트

seed 키 유출 미포함 테스트 추가 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자 프로필 조회 시 민감한 정보가 응답에서 제외되도록 수정되었습니다.
  * 지갑 주소와 공개 키는 여전히 포함됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/K-Statra/backend/pull/39)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->