### PR TITLE
[REFACTOR] XRPL 에스크로 큐 backoff 최적화 및 재연결 안정성 개선

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,27 @@ services:
   mongo:
     image: mongo:6
     restart: unless-stopped
+    command: ["--replSet", "rs0", "--bind_ip_all"]
     ports:
       - "27017:27017"
     volumes:
       - mongo_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  mongo-init:
+    image: mongo:6
+    depends_on:
+      mongo:
+        condition: service_healthy
+    entrypoint: >
+      mongosh --host mongo:27017 --eval
+      'try { rs.status(); print("already initiated") } catch(e) { rs.initiate({_id:"rs0",members:[{_id:0,host:"localhost:27017"}]}); print("initiated") }'
+    restart: "no"
 
   redis:
     image: redis:alpine

--- a/src/modules/outbox/outbox-watcher.service.ts
+++ b/src/modules/outbox/outbox-watcher.service.ts
@@ -130,11 +130,11 @@ export class OutboxWatcherService
     if (!acquired) return; // 다른 인스턴스가 먼저 처리함
 
     // 금액 오류는 프로세서에서 즉시 중단, 그 외(네트워크 등)는 적극 재시도
-    // 10회, 초기 60초 지수 백오프 → 최대 누적 대기 ~17시간
+    // 10회, 초기 5초 지수 백오프 → 최대 누적 대기 ~43분
     try {
       await this.escrowCreateQueue.add(doc.payload as EscrowCreateJobData, {
         attempts: 10,
-        backoff: { type: "exponential", delay: 60_000 },
+        backoff: { type: "exponential", delay: 5_000 },
       });
     } catch (err: any) {
       this.logger.error(

--- a/src/modules/xrpl/xrpl.service.ts
+++ b/src/modules/xrpl/xrpl.service.ts
@@ -92,20 +92,31 @@ export class XrplService implements OnModuleInit, OnModuleDestroy {
 
   // 중복 websocket 중복 연결 방지 및 재연결 로직
   private async connect() {
-    if (!this.client) {
-      this.client = new Client(this.wsUrl);
-    }
-    if (this.client.isConnected()) {
+    if (this.client?.isConnected()) {
       return;
     }
     if (!this.connectPromise) {
-      this.connectPromise = this.client.connect().finally(() => {
-        this.connectPromise = undefined;
-      });
+      // 연결이 끊긴 상태에서 재연결 시 기존 Client를 버리고 새로 생성
+      // 기존 Client를 재사용하면 "Websocket connection never cleaned up" 에러 발생
+      this.client = new Client(this.wsUrl, { connectionTimeout: 3_000 });
+      this.logger.log(`[XRPL] Connecting to ${this.wsUrl}`);
+      this.connectPromise = this.client
+        .connect()
+        .then(() => {
+          this.logger.log(`[XRPL] Connected to ${this.wsUrl}`);
+        })
+        .catch((err: Error) => {
+          this.logger.error(
+            `[XRPL] Connection failed (${this.wsUrl}): ${err.message}`,
+          );
+          throw err;
+        })
+        .finally(() => {
+          this.connectPromise = undefined;
+        });
     }
 
     await this.connectPromise;
-    this.logger.log(`Connected to XRPL: ${this.wsUrl}`);
   }
 
   // 신규 지갑 생성


### PR DESCRIPTION
Resolves #31 

## 문제

기존 `backoff: { type: "exponential", delay: 60_000 }` 설정으로
XRPL 네트워크 일시 장애 시 재시도 최대 누적 대기가 ~17시간에 달했습니다.
XRPL 트랜잭션 완료 시간이 3 ~ 5초임을 감안하면 과도한 설정이었습니다.

또한 연결이 끊긴 후 재연결 시 xrpl.js Client를 재사용해
`"Websocket connection never cleaned up"` 에러가 발생하는 버그가 있었습니다.

## 변경 사항

### 1. Backoff delay 단축 (`outbox-watcher.service.ts`)
- `delay: 60_000` → `delay: 5_000`
- 최대 누적 대기: ~17시간 → **~43분**

### 2. XRPL connectionTimeout 단축 (`xrpl.service.ts`)
- xrpl.js 기본값(5s) → `connectionTimeout: 3_000`
- 연결 실패 감지 속도 향상

### 3. 재연결 시 Client 새로 생성 (`xrpl.service.ts`)
- 연결 끊김 후 재연결 시 기존 Client를 버리고 새로 생성
- `"Websocket connection never cleaned up"` 에러 제거

### 4. 개발 도구 (`scripts/bull-board.ts`)
- Bull Board 대시보드 독립 실행 스크립트 추가
- `npx ts-node scripts/bull-board.ts` → http://localhost:3001/queues

### 5. MongoDB Replica Set (`docker-compose.yml`)
- Change Streams 지원을 위한 단일 노드 replica set 구성 추가

## Chaos Test 결과

toxiproxy로 XRPL WebSocket 연결을 강제 차단/복구하며 실측

### delay=2000, connectionTimeout=5s (테스트 1)
| attempt | gap | 비고 |
|---------|-----|------|
| 0→1 | 22s | request timeout (~20s) + 5s backoff |
| 1→2 | 26s | request timeout (~18s) + 8s backoff |
| 2→3 | 14s | "Websocket never cleaned up" (즉시) + 16s backoff |
| 3→4 | 35s | 5s connection timeout + 32s backoff |
| 4→5 | 67s | 5s connection timeout + 64s backoff |
| **총** | **~2m44s** | |

### delay=5000, connectionTimeout=3s (테스트 2 — never cleaned up 버그 있음)
| attempt | gap | 비고 |
|---------|-----|------|
| 0→1 | 25s | request timeout (~20s) + 5s backoff |
| 1→2 | 15s | "Websocket never cleaned up" (즉시) + 10s backoff |
| 2→3 | 35s | "Websocket never cleaned up" (즉시) + 20s backoff |
| 3→4 | 78s | 3s connection timeout + 75s backoff |
| 4→5 | 158s | 3s connection timeout + 155s backoff |
| **총** | **~5m12s** | |

### delay=5000, connectionTimeout=3s (최종 — connect() 수정 후)
| attempt | gap | 비고 |
|---------|-----|------|
| 0→1 | 25s | request timeout (~20s) + 5s backoff |
| 1→2 | 18s | 3s connection timeout + 15s backoff ✅ |
| 2→3 | 38s | 3s connection timeout + 35s backoff ✅ |
| 3→4 | 78s | 3s connection timeout + 75s backoff ✅ |
| 4→5 | 158s | 3s connection timeout + 155s backoff ✅ |
| **총** | **~5m17s** | "never cleaned up" 완전 제거 |

## 결과

| | 수정 전 | 수정 후 |
|--|---------|---------|
| attempt=1 에러 유형 | "Websocket never cleaned up" | connect() timed out (3s) ✅ |
| backoff 공식 | `delay × (2ⁿ - 1)` | 동일, delay만 변경 |
| 첫 retry 간격 | ~25s (5s backoff + 20s request timeout) | ~25s (동일) |
| 5회 retry 누적 | ~5분 12초 | ~5분 17초 (안정적) |
| 최대 누적 (10회) | ~17시간 | **~43분** |

> attempt=0의 ~20초 지연은 xrpl.js 내부 request timeout으로 backoff 설정과 무관합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 이벤트 처리 재시도 로직 조정
  * XRPL WebSocket 연결 안정성 개선

* **Refactor**
  * MongoDB 레플리카셋 초기화 및 헬스체크 프로세스 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/K-Statra/backend/pull/49)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->