### PR TITLE
[FIX] 파트너 검색 병합 전략을 RRF로 교체 및 키워드 품질 개선

### DIFF
--- a/src/modules/partners/partners.service.spec.ts
+++ b/src/modules/partners/partners.service.spec.ts
@@ -146,7 +146,7 @@ describe("PartnersService", () => {
       expect(result.provider).toBe("db");
     });
 
-    it("embed 빈 벡터 → 텍스트 검색 폴백, 스코어 정규화 및 부스트", async () => {
+    it("embed 빈 벡터 → 텍스트 검색 폴백, RRF 점수 적용", async () => {
       embeddingsService.embed.mockResolvedValue([]);
       sellerModel.find.mockReturnValue(
         buildQueryMock([
@@ -162,8 +162,10 @@ describe("PartnersService", () => {
       const result = await service.search({ q: "화장품" });
 
       expect(sellerModel.find).toHaveBeenCalled();
-      // 계산: (min(1, 12/12) * 0.7) + 0.3(부스트) = 0.7 + 0.3 = 1.0
-      expect(result.data[0].score).toBeCloseTo(1.0);
+      // RRF: 텍스트 rank=1, 벡터 없음(GHOST_RANK=500)
+      // score = 1/(60+500) + 1/(60+1) ≈ 0.0182
+      const expected = 1 / (60 + 500) + 1 / (60 + 1);
+      expect(result.data[0].score).toBeCloseTo(expected, 4);
     });
 
     it("벡터 검색 결과 0건 → 텍스트 검색 폴백", async () => {

--- a/src/modules/partners/partners.service.ts
+++ b/src/modules/partners/partners.service.ts
@@ -390,6 +390,7 @@ export class PartnersService {
     let dbResults: any[] = [];
     if (vectorResults.length > 0 || textResults.length > 0) {
       const K = 60;
+      const GHOST_RANK = 500;
 
       const vectorRankMap = new Map(
         [...vectorResults]
@@ -414,7 +415,6 @@ export class PartnersService {
 
       dbResults = [...allIds]
         .map((id) => {
-          const GHOST_RANK = 500;
           const vRank = vectorRankMap.get(id) ?? GHOST_RANK;
           const tRank = textRankMap.get(id) ?? GHOST_RANK;
           const base = vectorDocMap.get(id) ?? textDocMap.get(id);

--- a/src/modules/partners/partners.service.ts
+++ b/src/modules/partners/partners.service.ts
@@ -933,6 +933,7 @@ const GENERIC_KEYWORD_BLOCKLIST = new Set([
 ]);
 
 function filterGenericKeywords(keywords: string): string {
+  if (!keywords) return keywords ?? "";
   const filtered = keywords
     .split(/\s*,\s*/) // 쉼표 기준으로만 분리 — 복합어("Smart Farm") 보존
     .map((w) => w.trim())

--- a/src/modules/partners/partners.service.ts
+++ b/src/modules/partners/partners.service.ts
@@ -217,7 +217,7 @@ export class PartnersService {
       // 1.0 AI Query Understanding (HyDE + Keywords)
       const aiAnalysis = await this.generateHyDEAndKeywords(q, detectedIntent);
       hydeDocument = aiAnalysis.profile;
-      aiKeywords = aiAnalysis.keywords;
+      aiKeywords = filterGenericKeywords(aiAnalysis.keywords);
 
       this.logger.log(
         `[Step 2.AI Analysis] took ${Math.round(performance.now() - aiStartTime)}ms. Keywords: "${aiKeywords}"`,
@@ -881,6 +881,64 @@ Output in JSON: { "profile": "...", "keywords": "..." }`,
 
     return scores;
   }
+}
+
+// --- Generic keyword filter ---
+const GENERIC_KEYWORD_BLOCKLIST = new Set([
+  "솔루션",
+  "기술",
+  "서비스",
+  "시스템",
+  "플랫폼",
+  "제품",
+  "제품군",
+  "글로벌",
+  "혁신",
+  "스마트",
+  "디지털",
+  "자동화",
+  "인공지능",
+  "분야",
+  "전문",
+  "개발",
+  "공급",
+  "사업",
+  "기업",
+  "회사",
+  "산업",
+  "solution",
+  "solutions",
+  "technology",
+  "technologies",
+  "service",
+  "services",
+  "system",
+  "systems",
+  "platform",
+  "platforms",
+  "product",
+  "products",
+  "global",
+  "innovation",
+  "smart",
+  "digital",
+  "automation",
+  "ai",
+  "company",
+  "business",
+  "industry",
+  "development",
+  "supply",
+]);
+
+function filterGenericKeywords(keywords: string): string {
+  const filtered = keywords
+    .split(/\s*,\s*/) // 쉼표 기준으로만 분리 — 복합어("Smart Farm") 보존
+    .map((w) => w.trim())
+    .filter(
+      (w) => w.length > 0 && !GENERIC_KEYWORD_BLOCKLIST.has(w.toLowerCase()),
+    );
+  return filtered.join(" ") || keywords; // 전부 걸리면 원본 fallback
 }
 
 // --- Keyword constants ---

--- a/src/modules/partners/partners.service.ts
+++ b/src/modules/partners/partners.service.ts
@@ -716,6 +716,7 @@ export class PartnersService {
         forceWebSearch,
         tavilyQuery: tavilyQuery || null,
         hydeDocument,
+        aiKeywords,
         duration: `${totalDuration}ms`,
       },
     };

--- a/src/modules/partners/partners.service.ts
+++ b/src/modules/partners/partners.service.ts
@@ -386,57 +386,47 @@ export class PartnersService {
       await Promise.all([textSearchTask, vectorSearchTask]);
     }
 
-    // 1.3 Merge Results
+    // 1.3 Merge Results (Reciprocal Rank Fusion)
     let dbResults: any[] = [];
     if (vectorResults.length > 0 || textResults.length > 0) {
-      const resultMap = new Map<string, any>();
-      const boostKeywords = (aiKeywords || q || "")
-        .split(/[\s,]+/)
-        .map((w) => w.replace(/[.,]/g, "").trim())
-        .filter((w) => w.length > 1);
+      const K = 60;
 
-      // Add vector results first
-      vectorResults.forEach((r) => {
-        resultMap.set(r._id.toString(), {
-          ...r,
-          vectorScore: r.score,
-          textScore: 0,
-          score: r.score * 0.7,
-        });
-      });
+      const vectorRankMap = new Map(
+        [...vectorResults]
+          .sort((a, b) => b.score - a.score)
+          .map((r, i) => [r._id.toString(), i + 1]),
+      );
+      const textRankMap = new Map(
+        [...textResults]
+          .sort((a, b) => b.textScore - a.textScore)
+          .map((r, i) => [r._id.toString(), i + 1]),
+      );
 
-      textResults.forEach((r) => {
-        const id = r._id.toString();
-        const normText = Math.min(1.0, r.textScore / 12);
-        if (resultMap.has(id)) {
-          const existing = resultMap.get(id);
-          existing.textScore = r.textScore;
-          existing.score = existing.vectorScore * 0.4 + normText * 0.4 + 0.2;
-        } else {
-          resultMap.set(id, {
-            ...r,
-            vectorScore: 0,
-            textScore: r.textScore,
-            score: normText * 0.7,
-          });
-        }
-      });
+      const allIds = new Set([
+        ...vectorResults.map((r) => r._id.toString()),
+        ...textResults.map((r) => r._id.toString()),
+      ]);
 
-      // Post-Processing: Boost items whose names or industry contain AI keywords
-      resultMap.forEach((item) => {
-        const name = (item.name || "").toLowerCase();
-        const industryText = (item.industry || "").toLowerCase();
-        const hasKeywordMatch = boostKeywords.some((kw) => {
-          const kL = kw.toLowerCase();
-          const match = name.includes(kL) || industryText.includes(kL);
-          return match;
-        });
+      const vectorDocMap = new Map<string, any>();
+      vectorResults.forEach((r) => vectorDocMap.set(r._id.toString(), r));
+      const textDocMap = new Map<string, any>();
+      textResults.forEach((r) => textDocMap.set(r._id.toString(), r));
 
-        if (hasKeywordMatch) {
-          item.score = Math.min(1.0, item.score + 0.3);
-        }
-      });
-      dbResults = Array.from(resultMap.values())
+      dbResults = [...allIds]
+        .map((id) => {
+          const GHOST_RANK = 500;
+          const vRank = vectorRankMap.get(id) ?? GHOST_RANK;
+          const tRank = textRankMap.get(id) ?? GHOST_RANK;
+          const base = vectorDocMap.get(id) ?? textDocMap.get(id);
+          return {
+            ...base,
+            vectorScore: vectorDocMap.get(id)?.score ?? 0,
+            textScore: textDocMap.get(id)?.textScore ?? 0,
+            score: 1 / (K + vRank) + 1 / (K + tRank),
+            vectorRank: vRank,
+            textRank: tRank,
+          };
+        })
         .sort((a, b) => b.score - a.score)
         .slice(0, Number(limit));
     }


### PR DESCRIPTION
Resolves #54 

## 배경

기존 검색은 벡터 점수(cosine, 0~1)와 BM25 텍스트 점수(unbounded)를
가중합으로 합산한 뒤 키워드 일치 기업에 +0.3 flat boost를 적용했습니다.

문제:
- 두 점수의 스케일이 달라 정규화가 불안정
- "솔루션", "Technology" 같은 LLM 생성 범용 키워드가 이름에 포함된
  무관한 기업이 키워드 부스트로 상위 랭크
- 예: "스마트팜 농기계" 검색 시 애완동물 사료 기업이 "Farm" 단어 매칭으로 상위 진입

## 변경 사항

### 1. 병합 전략 → Reciprocal Rank Fusion (RRF)
- `score = 1/(K+vectorRank) + 1/(K+textRank)` (K=60)
- 절대 점수 대신 순위 기반 융합 → 스케일 불일치 근본 해결
- 한쪽 결과에만 있는 문서는 `GHOST_RANK=500` 고정 페널티 부여
  (기존 N×3 방식은 결과 집합 크기에 따라 페널티가 달라지는 버그 있었음)

### 2. LLM 키워드 범용어 필터
- `filterGenericKeywords()`: 솔루션/기술/서비스/system/solution 등
  한·영 범용어 블록리스트로 MongoDB `$text` 검색 전 사전 제거
- 구분자를 `\s*,\s*` (쉼표만)으로 변경 → "Smart Farm" 같은
  복합 영단어가 분리되지 않고 통째로 검색에 사용됨

### 3. debug 응답에 `aiKeywords` 노출
- 실제 `$text` 검색에 사용된 키워드 확인 가능

## 영향 범위

- `partners.service.ts` 단일 파일, API 스펙 변경 없음
- 응답 `debug` 객체에 `aiKeywords` 필드 추가 (하위 호환)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **개선사항**
  * 파트너 검색 결과의 정렬·랭킹 로직을 개선해 더 적합한 순위가 반환되도록 했습니다 (다중 랭킹을 결합한 방식).
  * 검색 입력의 범용(제네릭) 키워드를 자동으로 필터링해 불필요한 매칭을 줄였습니다.
  * 검색 결과의 디버그 정보에 AI 키워드 관련 정보가 추가되어 문제 분석이 용이합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/K-Statra/backend/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->